### PR TITLE
don't scroll page during specific focus() calls

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -655,7 +655,10 @@ define ['droplet-helper',
     else return null
 
   hook 'mousedown', 10, ->
+    x = document.body.scrollLeft
+    y = document.body.scrollTop
     @dropletElement.focus()
+    window.scrollTo(x, y)
 
   # UNDO STACK SUPPORT
   # ================================
@@ -1098,9 +1101,6 @@ define ['droplet-helper',
       )
 
       rect = @wrapperElement.getBoundingClientRect()
-
-      console.log position.x - @wrapperElement.getBoundingClientRect().left,
-          position.y - @wrapperElement.getBoundingClientRect().top
 
       @dragCanvas.style.top = "#{position.y - rect.top}px"
       @dragCanvas.style.left = "#{position.x - rect.left}px"
@@ -4049,7 +4049,11 @@ define ['droplet-helper',
   hook 'keydown', 0, (event, state) ->
     if event.which in command_modifiers
       unless @textFocus?
+        x = document.body.scrollLeft
+        y = document.body.scrollTop
         @copyPasteInput.focus()
+        window.scrollTo(x, y)
+
         if @lassoSegment?
           @copyPasteInput.value = @lassoSegment.stringify(@mode.empty)
         @copyPasteInput.setSelectionRange 0, @copyPasteInput.value.length


### PR DESCRIPTION
I found two places where droplet was scrolling the page unexpectedly due to focus() calls
1. when it receives a mousedown. fixed this using the well documented method of capturing position before the focus() call and calling scrollTo with previous position after the focus() call
2. when it receives a "cmd-key" press (I saw this frequently while using Cmd-Tab to switch away from the browser). Using the same technique.

Now the page doesn't jump around unexpectedly!
Also removed a noisy console.log statement with coords during drag.

The only question in my mind is browser compatibility for document.body.scrollLeft and scrollTop - I tested on Chrome 38. I don't know which browsers droplet supports.
