### PR TITLE
move resizeGutter() call after dropletElement height is set

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -330,11 +330,12 @@ define ['droplet-helper',
 
     resizeBlockMode: ->
       @resizeTextMode()
-      @resizeGutter()
 
       @dropletElement.style.left = "#{@paletteElement.offsetWidth}px"
       @dropletElement.style.height = "#{@wrapperElement.offsetHeight}px"
       @dropletElement.style.width ="#{@wrapperElement.offsetWidth - @paletteWrapper.offsetWidth}px"
+
+      @resizeGutter()
 
       @mainCanvas.height = @dropletElement.offsetHeight
       @mainCanvas.width = @dropletElement.offsetWidth - @gutter.offsetWidth


### PR DESCRIPTION
The gutter was initially appearing with only a 23 pixel height. After a resize, it would properly grow its height to match the dropletElement height.

Changed the order of calls in resizeBlockMode so resizeGutter() is called after the dropletElement height is set.
