### PR TITLE
LogicalExpressions precedence fix

### DIFF
--- a/src/javascript.coffee
+++ b/src/javascript.coffee
@@ -97,6 +97,10 @@ define ['droplet-helper', 'droplet-model', 'droplet-parser', 'acorn'], (helper, 
   # See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence
   # These numbers are "19 - x" so that the lowest numbers bind most tightly.
   OPERATOR_PRECEDENCES = {
+    '++': 3
+    '--': 3
+    '!': 4
+    '~': 4
     '*': 5
     '/': 5
     '%': 5
@@ -149,8 +153,6 @@ define ['droplet-helper', 'droplet-model', 'droplet-parser', 'acorn'], (helper, 
         allowReturnOutsideFunction: true
       })
 
-      #console.log 'PROGRAM IS', JSON.stringify tree, null, 2
-
       @mark 0, tree, 0, null
 
     fullFunctionNameArray: (node) ->
@@ -200,15 +202,15 @@ define ['droplet-helper', 'droplet-model', 'droplet-parser', 'acorn'], (helper, 
 
     getPrecedence: (node) ->
       switch node.type
-        when 'BinaryExpression'
+        when 'BinaryExpression', 'LogicalExpression'
           return OPERATOR_PRECEDENCES[node.operator]
         when 'AssignStatement'
           return 16
         when 'UnaryExpression'
           if node.prefix
-            return 4
+            return OPERATOR_PRECEDENCES[node.operator] ? 4
           else
-            return 3
+            return OPERATOR_PRECEDENCES[node.operator] ? 3
         when 'CallExpression'
           return 2
         when 'NewExpression'

--- a/src/javascript.coffee
+++ b/src/javascript.coffee
@@ -437,8 +437,8 @@ define ['droplet-helper', 'droplet-model', 'droplet-parser', 'acorn'], (helper, 
             @jsSocketAndMark indentDepth, node.init, depth
         when 'LogicalExpression'
           @jsBlock node, depth, bounds
-          @jsSocketAndMark indentDepth, node.left, depth + 1
-          @jsSocketAndMark indentDepth, node.right, depth + 1
+          @jsSocketAndMark indentDepth, node.left, depth + 1, @getPrecedence node
+          @jsSocketAndMark indentDepth, node.right, depth + 1, @getPrecedence node
         when 'WhileStatement', 'DoWhileStatement'
           @jsBlock node, depth, bounds
           @jsSocketAndMark indentDepth, node.body, depth + 1

--- a/test/jstest.html
+++ b/test/jstest.html
@@ -240,6 +240,143 @@ function(helper, JavaScript, droplet) {
     start();
   });
 
+  asyncTest('JS LogicalExpressions', function() {
+    var customJS, customSerialization, expectedSerialization;
+    customJS = new JavaScript();
+    customSerialization = customJS.parse(
+        'a && b').serialize();
+    expectedSerialization =
+        '<segment' +
+        '  isLassoSegment="false"' +
+        '><block' +
+        '  precedence="13"' +
+        '  color="cyan"' +
+        '  socketLevel="0"' +
+        '  classes="LogicalExpression mostly-value"' +
+        '><socket' +
+        '  precedence="13"' +
+        '  handwritten="false"' +
+        '  classes=""' +
+        '>a</socket> &amp;&amp; ' +
+        '<socket' +
+        '  precedence="13"' +
+        '  handwritten="false"' +
+        '  classes=""' +
+        '>b</socket></block></segment>';
+    strictEqual(
+        helper.xmlPrettyPrint(customSerialization),
+        helper.xmlPrettyPrint(expectedSerialization),
+        'Logical expression precedences are assigned.');
+    start();
+  });
+
+  asyncTest('JS Custom Colors', function() {
+    var customJS, customSerialization, expectedSerialization;
+    customJS = new JavaScript({
+      categories: {
+        functions: {color: '#111'},
+        returns: {color: '#222'},
+        comments: {color: '#333'},
+        arithmetic: {color: '#444'},
+        containers: {color: '#666'},
+        assignments: {color: '#777'},
+        loops: {color: '#888'},
+        conditionals: {color: '#999'},
+        value: {color: '#aaa'},
+        command: {color: '#bbb'}
+      }
+    });
+    customSerialization = customJS.parse(
+        'return b != (a += [c + d][0]);').serialize();
+    expectedSerialization =
+      '<segment' +
+      '  isLassoSegment="false"' +
+      '><block' +
+      '  precedence="0"' +
+      '  color="#222"' +  // returns
+      '  socketLevel="0"' +
+      '  classes="ReturnStatement mostly-block"' +
+      '>return <socket' +
+      '  precedence="0"' +
+      '  handwritten="false"' +
+      '  classes=""' +
+      '><block' +
+      '  precedence="9"' +
+      '  color="cyan"' +  // logic - not overridden
+      '  socketLevel="0"' +
+      '  classes="BinaryExpression mostly-value"' +
+      '><socket' +
+      '  precedence="9"' +
+      '  handwritten="false"' +
+      '  classes=""' +
+      '>b</socket' +
+      '> != <socket' +
+      '  precedence="9"' +
+      '  handwritten="false"' +
+      '  classes=""' +
+      '><block' +
+      '  precedence="0"' +
+      '  color="#777"' +  // assignment
+      '  socketLevel="0"' +
+      '  classes="mostly-block AssignmentExpression"' +
+      '>(<socket' +
+      '  precedence="0"' +
+      '  handwritten="false"' +
+      '  classes=""' +
+      '>a</socket' +
+      '> += <socket' +
+      '  precedence="0"' +
+      '  handwritten="false"' +
+      '  classes=""' +
+      '><block' +
+      '  precedence="1"' +
+      '  color="#666"' +  // containers
+      '  socketLevel="0"' +
+      '  classes="MemberExpression mostly-value"' +
+      '><socket' +
+      '  precedence="0"' +
+      '  handwritten="false"' +
+      '  classes=""' +
+      '><block' +
+      '  precedence="0"' +
+      '  color="#666"' +  // containers
+      '  socketLevel="0"' +
+      '  classes="ArrayExpression mostly-value"' +
+      '>[<socket' +
+      '  precedence="0"' +
+      '  handwritten="false"' +
+      '  classes=""' +
+      '><block' +
+      '  precedence="6"' +
+      '  color="#444"' +   // arithmetic
+      '  socketLevel="0"' +
+      '  classes="BinaryExpression mostly-value"' +
+      '><socket' +
+      '  precedence="6"' +
+      '  handwritten="false"' +
+      '  classes=""' +
+      '>c</socket' +
+      '> + <socket' +
+      '  precedence="6"' +
+      '  handwritten="false"' +
+      '  classes=""' +
+      '>d</socket></block></socket' +
+      '>]</block></socket' +
+      '>[<socket' +
+      '  precedence="0"' +
+      '  handwritten="false"' +
+      '  classes=""' +
+      '>0</socket' +
+      '>]</block></socket' +
+      '>)</block></socket></block></socket' +
+      '>;</block></segment>';
+    strictEqual(
+        helper.xmlPrettyPrint(customSerialization),
+        helper.xmlPrettyPrint(expectedSerialization),
+        'JS Custom colors work');
+    start();
+  });
+
 });
 </script>
 </html>


### PR DESCRIPTION
Precedences for LogicalExpressions and to some degree UnaryExpressions were formerly not assigned the same way they were for BinaryExpressions; this PR fixes precedences assignments.