### PR TITLE
Don't make blocks for unary operators on literal values

### DIFF
--- a/src/javascript.coffee
+++ b/src/javascript.coffee
@@ -409,8 +409,10 @@ define ['droplet-helper', 'droplet-model', 'droplet-parser', 'acorn'], (helper, 
           @jsSocketAndMark indentDepth, node.left, depth + 1, OPERATOR_PRECEDENCES[node.operator]
           @jsSocketAndMark indentDepth, node.right, depth + 1, OPERATOR_PRECEDENCES[node.operator]
         when 'UnaryExpression'
-          @jsBlock node, depth, bounds
-          @jsSocketAndMark indentDepth, node.argument, depth + 1, @getPrecedence node
+          unless node.operator in ['-', '+'] and
+              node.argument.type in ['Identifier', 'Literal']
+            @jsBlock node, depth, bounds
+            @jsSocketAndMark indentDepth, node.argument, depth + 1, @getPrecedence node
         when 'ExpressionStatement'
           @mark indentDepth, node.expression, depth + 1, @getBounds node
         when 'Identifier'

--- a/test/jstest.html
+++ b/test/jstest.html
@@ -300,6 +300,65 @@ function(helper, JavaScript, droplet) {
     start();
   });
 
+  asyncTest('JS omits unary +/- for literals', function() {
+    var customJS, customSerialization, expectedSerialization;
+    customJS = new JavaScript();
+    customSerialization = customJS.parse(
+        'foo(+1, -1, +a());').serialize();
+    expectedSerialization =
+        '<segment' +
+        '  isLassoSegment="false"' +
+        '><block' +
+        '  precedence="2"' +
+        '  color="blue"' +
+        '  socketLevel="0"' +
+        '  classes="CallExpression any-drop"' +
+        '><socket' +
+        '  precedence="100"' +
+        '  handwritten="false"' +
+        '  classes=""' +
+        '>foo</socket>(' +
+        '<socket' +
+        '  precedence="100"' +
+        '  handwritten="false"' +
+        '  classes=""' +
+        '>+1</socket>, ' +
+        '<socket' +
+        '  precedence="100"' +
+        '  handwritten="false"' +
+        '  classes=""' +
+        '>-1</socket>, ' +
+        '<socket' +
+        '  precedence="100"' +
+        '  handwritten="false"' +
+        '  classes=""' +
+        '><block '  +
+        '  precedence="6"' +
+        '  color="green"' +
+        '  socketLevel="0"' +
+        '  classes="UnaryExpression mostly-value"' +
+        '>+<socket ' +
+        '  precedence="6"' +
+        '  handwritten="false"' +
+        '  classes=""' +
+        '><block ' +
+        '  precedence="2"' +
+        '  color="blue"' +
+        '  socketLevel="0"' +
+        '  classes="CallExpression any-drop"' +
+        '><socket ' +
+        '  precedence="100"' +
+        '  handwritten="false"' +
+        '  classes=""' +
+        '>a</socket>()</block></socket></block>' +
+        '</socket>);</block></segment>';
+    strictEqual(
+        helper.xmlPrettyPrint(customSerialization),
+        helper.xmlPrettyPrint(expectedSerialization),
+        'Unary literal +/- are not parsed, but unary nonliteral operators are');
+    start();
+  });
+
   asyncTest('JS Custom Colors', function() {
     var customJS, customSerialization, expectedSerialization;
     customJS = new JavaScript({


### PR DESCRIPTION
For editing convenience, no longer make a block for values like `-1` or `+foo`.