### PR TITLE
Allow users to abort drags by replacing the block where they found it

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "browserify": "^10.2.4",
     "browserify-shim": "^3.8.8",
     "coffeeify": "^1.1.0",
-    "grunt": "latest",
+    "grunt": "0.4.5",
     "grunt-banner": "latest",
     "grunt-bowercopy": "latest",
     "grunt-browserify": "^3.8.0",

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -1158,21 +1158,31 @@ hook 'mousemove', 0, (point, event, state) ->
       @lastHighlight = @tree
 
     else
-      # Find the closest droppable block
-      testPoints = @dropPointQuadTree.retrieve {
-        x: mainPoint.x - MAX_DROP_DISTANCE
-        y: mainPoint.y - MAX_DROP_DISTANCE
-        w: MAX_DROP_DISTANCE * 2
-        h: MAX_DROP_DISTANCE * 2
-      }, (point) =>
-        unless (point.acceptLevel is helper.DISCOURAGE) and not event.shiftKey
-          distance = mainPoint.from(point)
-          distance.y *= 2; distance = distance.magnitude()
-          if distance < min and mainPoint.from(point).magnitude() < MAX_DROP_DISTANCE and
-             @view.getViewNodeFor(point._ice_node).highlightArea?
-            best = point._ice_node
-            min = distance
+      # If the user is touching the original location,
+      # assume they want to replace the block where they found it.
+      if @hitTest mainPoint, @draggingBlock
+        best = null
+      # Otherwise, find the closest droppable block
+      else
+        testPoints = @dropPointQuadTree.retrieve {
+          x: mainPoint.x - MAX_DROP_DISTANCE
+          y: mainPoint.y - MAX_DROP_DISTANCE
+          w: MAX_DROP_DISTANCE * 2
+          h: MAX_DROP_DISTANCE * 2
+        }, (point) =>
+          unless (point.acceptLevel is helper.DISCOURAGE) and not event.shiftKey
+            # Find a modified "distance" to the point
+            # that weights horizontal distance more
+            distance = mainPoint.from(point)
+            distance.y *= 2; distance = distance.magnitude()
 
+            # Select the node that is closest by said "distance"
+            if distance < min and mainPoint.from(point).magnitude() < MAX_DROP_DISTANCE and
+               @view.getViewNodeFor(point._ice_node).highlightArea?
+              best = point._ice_node
+              min = distance
+
+      # Update highlight if necessary.
       if best isnt @lastHighlight
         @clearHighlightCanvas()
 

--- a/test/src/uitest.coffee
+++ b/test/src/uitest.coffee
@@ -205,3 +205,33 @@ asyncTest 'Controller: does not throw on reparse error', ->
 
     start()
   ), 10)
+
+asyncTest 'Controller: Can replace a block where we found it', ->
+  document.getElementById('test-main').innerHTML = ''
+  window.editor = editor = new droplet.Editor(document.getElementById('test-main'), {
+    mode: 'javascript',
+    palette: []
+  })
+
+  editor.setEditorState(true)
+  editor.setValue('for (var i = 0; i < 5; i++) {\n' +
+                   '  fd(10);\n' +
+                   '}\n')
+  simulate('mousedown', '.droplet-main-scroller-stuffing', {dx: 300, dy: 30})
+  simulate('mousemove', '.droplet-drag-cover'
+    {location: '.droplet-main-scroller-stuffing', dx: 305, dy: 35})
+  simulate('mouseup', '.droplet-drag-cover'
+    {location: '.droplet-main-scroller-stuffing', dx: 305, dy: 35})
+  equal(editor.getValue() , 'for (var i = 0; i < 5; i++) {\n' +
+                            '  fd(10);\n' +
+                            '}\n')
+
+  simulate('mousedown', '.droplet-main-scroller-stuffing', {dx: 300, dy: 30})
+  simulate('mousemove', '.droplet-drag-cover'
+    {location: '.droplet-main-scroller-stuffing', dx: 290, dy: 25})
+  simulate('mouseup', '.droplet-drag-cover'
+    {location: '.droplet-main-scroller-stuffing', dx: 290, dy: 25})
+  equal(editor.getValue() , 'for (var i = 0; i < i++; __) {\n' +
+                            '  fd(10);\n' +
+                            '}\n')
+  start()

--- a/test/uitest.html
+++ b/test/uitest.html
@@ -4,12 +4,8 @@
     <link rel="stylesheet" href="../dist/droplet.min.css"/>
     <style>
       #test-main {
-        position: absolute;
-        top: 100px;
-        right: 0;
-        border: 5px solid red;
-        height: 300px;
-        width: 500px;
+        width: 1000px; height: 1000px;
+        opacity: 0.3;
       }
     </style>
   </head>


### PR DESCRIPTION
Change to `controller.coffee` to abort a drag if the user is hovering over the grayed-out block that represents the place they picked up the block. I don't know if this is a good UI decision -- thoughts?