### PR TITLE
Gutter compat

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -194,6 +194,7 @@ module.exports = (grunt) ->
         console.log 'Livereload server listening on 35729'
 
       w.on 'update', ->
+        console.log 'File changed...'
         stream = fs.createWriteStream 'dist/droplet-full.js'
         w.bundle().pipe stream
         stream.once 'close', ->

--- a/css/droplet.css
+++ b/css/droplet.css
@@ -256,3 +256,8 @@
 .droplet-dropdown-item:hover {
   background-color: #DDD;
 }
+.droplet_error {
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAABOFBMVEX/////////QRswFAb/Ui4wFAYwFAYwFAaWGAfDRymzOSH/PxswFAb/SiUwFAYwFAbUPRvjQiDllog5HhHdRybsTi3/Tyv9Tir+Syj/UC3////XurebMBIwFAb/RSHbPx/gUzfdwL3kzMivKBAwFAbbvbnhPx66NhowFAYwFAaZJg8wFAaxKBDZurf/RB6mMxb/SCMwFAYwFAbxQB3+RB4wFAb/Qhy4Oh+4QifbNRcwFAYwFAYwFAb/QRzdNhgwFAYwFAbav7v/Uy7oaE68MBK5LxLewr/r2NXewLswFAaxJw4wFAbkPRy2PyYwFAaxKhLm1tMwFAazPiQwFAaUGAb/QBrfOx3bvrv/VC/maE4wFAbRPBq6MRO8Qynew8Dp2tjfwb0wFAbx6eju5+by6uns4uH9/f36+vr/GkHjAAAAYnRSTlMAGt+64rnWu/bo8eAA4InH3+DwoN7j4eLi4xP99Nfg4+b+/u9B/eDs1MD1mO7+4PHg2MXa347g7vDizMLN4eG+Pv7i5evs/v79yu7S3/DV7/498Yv24eH+4ufQ3Ozu/v7+y13sRqwAAADLSURBVHjaZc/XDsFgGIBhtDrshlitmk2IrbHFqL2pvXf/+78DPokj7+Fz9qpU/9UXJIlhmPaTaQ6QPaz0mm+5gwkgovcV6GZzd5JtCQwgsxoHOvJO15kleRLAnMgHFIESUEPmawB9ngmelTtipwwfASilxOLyiV5UVUyVAfbG0cCPHig+GBkzAENHS0AstVF6bacZIOzgLmxsHbt2OecNgJC83JERmePUYq8ARGkJx6XtFsdddBQgZE2nPR6CICZhawjA4Fb/chv+399kfR+MMMDGOQAAAABJRU5ErkJggg==");
+  background-repeat: no-repeat;
+  background-position: 2px 35%;
+}

--- a/css/droplet.css
+++ b/css/droplet.css
@@ -261,3 +261,9 @@
   background-repeat: no-repeat;
   background-position: 2px 35%;
 }
+
+.droplet_warning {
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAmVBMVEX///8AAAD///8AAAAAAABPSzb/5sAAAAB/blH/73z/ulkAAAAAAAD85pkAAAAAAAACAgP/vGz/rkDerGbGrV7/pkQICAf////e0IsAAAD/oED/qTvhrnUAAAD/yHD/njcAAADuv2r/nz//oTj/p064oGf/zHAAAAA9Nir/tFIAAAD/tlTiuWf/tkIAAACynXEAAAAAAAAtIRW7zBpBAAAAM3RSTlMAABR1m7RXO8Ln31Z36zT+neXe5OzooRDfn+TZ4p3h2hTf4t3k3ucyrN1K5+Xaks52Sfs9CXgrAAAAjklEQVR42o3PbQ+CIBQFYEwboPhSYgoYunIqqLn6/z8uYdH8Vmdnu9vz4WwXgN/xTPRD2+sgOcZjsge/whXZgUaYYvT8QnuJaUrjrHUQreGczuEafQCO/SJTufTbroWsPgsllVhq3wJEk2jUSzX3CUEDJC84707djRc5MTAQxoLgupWRwW6UB5fS++NV8AbOZgnsC7BpEAAAAABJRU5ErkJggg==");
+  background-repeat: no-repeat;
+  background-position: 2px 35%;
+}

--- a/css/droplet.css
+++ b/css/droplet.css
@@ -273,3 +273,31 @@
   background-repeat: no-repeat;
   background-position: 2px center;
 }
+.droplet-tooltip {
+  font-family: Courier, monospace;
+  margin-top: 15px;
+  margin-left: 15px;
+  display: none;
+  background-color: #FFF;
+  background-image: -webkit-linear-gradient(top, transparent, rgba(0, 0, 0, 0.1));
+  background-image: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.1));
+  border: 1px solid gray;
+  border-radius: 1px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  color: black;
+  max-width: 100%;
+  padding: 3px 4px;
+  position: fixed;
+  z-index: 999999;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  cursor: default;
+  white-space: pre;
+  word-wrap: break-word;
+  line-height: normal;
+  font-style: normal;
+  font-weight: normal;
+  letter-spacing: normal;
+  pointer-events: none;
+}

--- a/css/droplet.css
+++ b/css/droplet.css
@@ -298,6 +298,7 @@
   line-height: normal;
   font-style: normal;
   font-weight: normal;
+  font-size: 15px;
   letter-spacing: normal;
   pointer-events: none;
 }

--- a/css/droplet.css
+++ b/css/droplet.css
@@ -259,11 +259,17 @@
 .droplet_error {
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAABOFBMVEX/////////QRswFAb/Ui4wFAYwFAYwFAaWGAfDRymzOSH/PxswFAb/SiUwFAYwFAbUPRvjQiDllog5HhHdRybsTi3/Tyv9Tir+Syj/UC3////XurebMBIwFAb/RSHbPx/gUzfdwL3kzMivKBAwFAbbvbnhPx66NhowFAYwFAaZJg8wFAaxKBDZurf/RB6mMxb/SCMwFAYwFAbxQB3+RB4wFAb/Qhy4Oh+4QifbNRcwFAYwFAYwFAb/QRzdNhgwFAYwFAbav7v/Uy7oaE68MBK5LxLewr/r2NXewLswFAaxJw4wFAbkPRy2PyYwFAaxKhLm1tMwFAazPiQwFAaUGAb/QBrfOx3bvrv/VC/maE4wFAbRPBq6MRO8Qynew8Dp2tjfwb0wFAbx6eju5+by6uns4uH9/f36+vr/GkHjAAAAYnRSTlMAGt+64rnWu/bo8eAA4InH3+DwoN7j4eLi4xP99Nfg4+b+/u9B/eDs1MD1mO7+4PHg2MXa347g7vDizMLN4eG+Pv7i5evs/v79yu7S3/DV7/498Yv24eH+4ufQ3Ozu/v7+y13sRqwAAADLSURBVHjaZc/XDsFgGIBhtDrshlitmk2IrbHFqL2pvXf/+78DPokj7+Fz9qpU/9UXJIlhmPaTaQ6QPaz0mm+5gwkgovcV6GZzd5JtCQwgsxoHOvJO15kleRLAnMgHFIESUEPmawB9ngmelTtipwwfASilxOLyiV5UVUyVAfbG0cCPHig+GBkzAENHS0AstVF6bacZIOzgLmxsHbt2OecNgJC83JERmePUYq8ARGkJx6XtFsdddBQgZE2nPR6CICZhawjA4Fb/chv+399kfR+MMMDGOQAAAABJRU5ErkJggg==");
   background-repeat: no-repeat;
-  background-position: 2px 35%;
+  background-position: 2px center;
 }
 
 .droplet_warning {
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAmVBMVEX///8AAAD///8AAAAAAABPSzb/5sAAAAB/blH/73z/ulkAAAAAAAD85pkAAAAAAAACAgP/vGz/rkDerGbGrV7/pkQICAf////e0IsAAAD/oED/qTvhrnUAAAD/yHD/njcAAADuv2r/nz//oTj/p064oGf/zHAAAAA9Nir/tFIAAAD/tlTiuWf/tkIAAACynXEAAAAAAAAtIRW7zBpBAAAAM3RSTlMAABR1m7RXO8Ln31Z36zT+neXe5OzooRDfn+TZ4p3h2hTf4t3k3ucyrN1K5+Xaks52Sfs9CXgrAAAAjklEQVR42o3PbQ+CIBQFYEwboPhSYgoYunIqqLn6/z8uYdH8Vmdnu9vz4WwXgN/xTPRD2+sgOcZjsge/whXZgUaYYvT8QnuJaUrjrHUQreGczuEafQCO/SJTufTbroWsPgsllVhq3wJEk2jUSzX3CUEDJC84707djRc5MTAQxoLgupWRwW6UB5fS++NV8AbOZgnsC7BpEAAAAABJRU5ErkJggg==");
   background-repeat: no-repeat;
-  background-position: 2px 35%;
+  background-position: 2px center;
+}
+
+.droplet_info {
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAAAAAA6mKC9AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAAJ0Uk5TAAB2k804AAAAPklEQVQY02NgIB68QuO3tiLznjAwpKTgNyDbMegwisCHZUETUZV0ZqOquBpXj2rtnpSJT1AEnnRmL2OgGgAAIKkRQap2htgAAAAASUVORK5CYII=");
+  background-repeat: no-repeat;
+  background-position: 2px center;
 }

--- a/example/example.coffee
+++ b/example/example.coffee
@@ -38,7 +38,7 @@ dropletConfig.setValue localStorage.getItem('config') ? '''
   }
 '''
 
-window.editor = editor = null
+editor = null
 
 # Droplet itself
 createEditor = (options) ->
@@ -55,6 +55,8 @@ createEditor = (options) ->
 
   editor.on 'change', ->
     localStorage.setItem 'text', editor.getValue()
+
+  window.editor = editor
 
 createEditor JSON.parse dropletConfig.getValue()
 

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -4235,7 +4235,7 @@ hook 'populate', 0, ->
   @annotations = {}
   @breakpoints = {}
 
-  @aceEditor.on 'guttermousedown', (e) ->
+  @aceEditor.on 'guttermousedown', (e) =>
     # Ensure that the click actually happened
     # on a line and not just in gutter space.
     target = e.domEvent.target

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -4246,7 +4246,7 @@ hook 'populate', 0, ->
     # mousedown event.
     row = e.getDocumentPosition().row
     e.stop()
-    @fireEvent 'guttermousedown', {line: row, event: e.domEvent}
+    @fireEvent 'guttermousedown', [{line: row, event: e.domEvent}]
 
 hook 'mousedown', 11, (point, event, state) ->
   # Check if mousedown within the gutter
@@ -4274,7 +4274,13 @@ Editor::setBreakpoint = (row) ->
   @redrawGutter false
 
 Editor::clearBreakpoint = (row) ->
+  @aceEditor.session.clearBreakpoint(row)
   @breakpoints[row] = false
+  @redrawGutter false
+
+Editor::clearBreakpoints = (row) ->
+  @aceEditor.session.clearBreakpoints()
+  @breakpoints = {}
   @redrawGutter false
 
 Editor::getBreakpoints = (row) ->

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -3638,6 +3638,7 @@ Editor::setFontSize_raw = (fontSize) ->
 
     @paletteHeader.style.fontSize = "#{fontSize}px"
     @gutter.style.fontSize = "#{fontSize}px"
+    @tooltipElement.style.fontSize = "#{fontSize}px"
 
     @view.opts.textHeight =
       @dragView.opts.textHeight = helper.getFontHeight @fontFamily, @fontSize
@@ -3665,6 +3666,7 @@ Editor::setFontFamily = (fontFamily) ->
 
   @view.clearCache(); @dragView.clearCache()
   @gutter.style.fontFamily = fontFamily
+  @tooltipElement.style.fontFamily = fontFamily
 
   @redrawMain()
   @rebuildPalette()

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -4273,7 +4273,7 @@ Editor::setBreakpoint = (row) ->
   # selectively apply classes
   @redrawGutter false
 
-Editor::getBreakpoitns = (row) ->
+Editor::getBreakpoints = (row) ->
   @aceEditor.session.getBreakpoints()
 
 Editor::setAnnotations = (annotations) ->
@@ -4283,6 +4283,8 @@ Editor::setAnnotations = (annotations) ->
   for el, i in annotations
     @annotations[el.row] ?= []
     @annotations[el.row].push el
+
+  console.log 'Just set annotations. They are now', @annotations
 
   @redrawGutter false
 
@@ -4308,12 +4310,12 @@ Editor::addLineNumberForLine = (line) ->
   # Add annotation mouseover text
   # and graphics
   if @annotations[line]?
-    lineDiv.className += ' ' + @annotations[line].map((x) -> x.type).join(' ')
+    lineDiv.className += ' droplet_' + getMostSevereAnnotationType(@annotations[line])
     lineDiv.title = @annotations[line].map((x) -> x.text).join('\n')
 
   # Add breakpoint graphics
   if @breakpoints[line]
-    lineDiv.className += ' droplet-gutter-breakpoint'
+    lineDiv.className += ' droplet_breakpoint'
 
   lineDiv.style.top = "#{treeView.bounds[line].y}px"
   lineDiv.style.paddingTop = "#{treeView.distanceToBase[line].above - @view.opts.textHeight - @fontAscent}px"
@@ -4321,6 +4323,12 @@ Editor::addLineNumberForLine = (line) ->
   lineDiv.style.fontSize = @fontSize + 'px'
 
   @lineNumberWrapper.appendChild lineDiv
+
+getMostSevereAnnotationType = (arr) ->
+  for el, i in arr
+    if el.type is 'error'
+      return 'error'
+  return 'warning'
 
 Editor::findLineNumberAtCoordinate = (coord) ->
   treeView = @view.getViewNodeFor @tree

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -4321,6 +4321,7 @@ Editor::addLineNumberForLine = (line) ->
   # and graphics
   if @annotations[line]?
     lineDiv.className += ' droplet_' + getMostSevereAnnotationType(@annotations[line])
+    lineDiv.style.backgroundPosition = "2px #{treeView.distanceToBase[line].above - @view.opts.textHeight - @fontAscent}px"
     lineDiv.title = @annotations[line].map((x) -> x.text).join('\n')
 
   # Add breakpoint graphics

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -3603,7 +3603,8 @@ hook 'redraw_main', 1, ->
   # jammed up against the edge of the screen.
   #
   # Default this extra space to fontSize (approx. 1 line).
-  @mainScrollerStuffing.style.height = "#{bounds.bottom() + (@options.extraBottomHeight ? @fontSize)}px"
+  @mainScrollerStuffing.style.height = "#{bounds.bottom() +
+    (@options.extraBottomHeight ? @fontSize)}px"
 
 hook 'redraw_palette', 0, ->
   bounds = new @draw.NoRectangle()
@@ -4287,7 +4288,9 @@ Editor::setAnnotations = (annotations) ->
 
 Editor::resizeGutter = ->
   @gutter.style.width = @aceEditor.renderer.$gutterLayer.gutterWidth + 'px'
-  @gutter.style.height = "#{Math.max @dropletElement.offsetHeight, @view.getViewNodeFor(@tree).totalBounds?.height ? 0}px"
+  @gutter.style.height = "#{Math.max(@dropletElement.offsetHeight,
+    (@view.getViewNodeFor(@tree).totalBounds?.bottom?() ? 0) +
+    (@options.extraBottomHeight ? @fontSize))}px"
 
 Editor::addLineNumberForLine = (line) ->
   treeView = @view.getViewNodeFor @tree
@@ -4358,7 +4361,7 @@ Editor::redrawGutter = (changedBox = true) ->
       delete @lineNumberTags[line]
 
   if changedBox
-    @gutter.style.height = "#{Math.max @mainScroller.offsetHeight, treeView.totalBounds.height}px"
+    @resizeGutter()
 
 Editor::setPaletteWidth = (width) ->
   @paletteWrapper.style.width = width + 'px'

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -3223,6 +3223,9 @@ Editor::performMeltAnimation = (fadeTime = 500, translateTime = 1000, cb = ->) -
       translatingElements.push div
 
       div.className = 'droplet-transitioning-element droplet-transitioning-gutter'
+      # Add annotation
+      if @annotations[line]?
+        div.className += ' droplet_' + getMostSevereAnnotationType(@annotations[line])
       div.style.transition = "left #{translateTime}ms, top #{translateTime}ms, font-size #{translateTime}ms"
 
       @dropletElement.appendChild div
@@ -3404,6 +3407,9 @@ Editor::performFreezeAnimation = (fadeTime = 500, translateTime = 500, cb = ->)-
             lineHeight - aceScrollTop}px"
 
         div.className = 'droplet-transitioning-element droplet-transitioning-gutter'
+        # Add annotation
+        if @annotations[line]?
+          div.className += ' droplet_' + getMostSevereAnnotationType(@annotations[line])
         div.style.transition = "left #{translateTime}ms, top #{translateTime}ms, font-size #{translateTime}ms"
         translatingElements.push div
 
@@ -4240,6 +4246,11 @@ hook 'populate', 0, ->
   @annotations = {}
   @breakpoints = {}
 
+  @tooltipElement = document.createElement 'div'
+  @tooltipElement.className = 'droplet-tooltip'
+
+  @dropletElement.appendChild @tooltipElement
+
   @aceEditor.on 'guttermousedown', (e) =>
     # Ensure that the click actually happened
     # on a line and not just in gutter space.
@@ -4324,7 +4335,18 @@ Editor::addLineNumberForLine = (line) ->
   # and graphics
   if @annotations[line]?
     lineDiv.className += ' droplet_' + getMostSevereAnnotationType(@annotations[line])
-    lineDiv.title = @annotations[line].map((x) -> x.text).join('\n')
+
+    title = @annotations[line].map((x) -> x.text).join('\n')
+
+    lineDiv.addEventListener 'mouseover', =>
+      @tooltipElement.innerText =
+        @tooltipElement.textContent = title
+      @tooltipElement.style.display = 'block'
+    lineDiv.addEventListener 'mousemove', (event) =>
+      @tooltipElement.style.left = event.pageX
+      @tooltipElement.style.top = event.pageY
+    lineDiv.addEventListener 'mouseout', =>
+      @tooltipElement.style.display = 'none'
 
   # Add breakpoint graphics
   if @breakpoints[line]

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -4273,6 +4273,10 @@ Editor::setBreakpoint = (row) ->
   # selectively apply classes
   @redrawGutter false
 
+Editor::clearBreakpoint = (row) ->
+  @breakpoints[row] = false
+  @redrawGutter false
+
 Editor::getBreakpoints = (row) ->
   @aceEditor.session.getBreakpoints()
 

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -4324,7 +4324,6 @@ Editor::addLineNumberForLine = (line) ->
   # and graphics
   if @annotations[line]?
     lineDiv.className += ' droplet_' + getMostSevereAnnotationType(@annotations[line])
-    #lineDiv.style.backgroundPosition = "2px #{treeView.distanceToBase[line].above - @view.opts.textHeight - @fontAscent}px"
     lineDiv.title = @annotations[line].map((x) -> x.text).join('\n')
 
   # Add breakpoint graphics
@@ -4348,9 +4347,7 @@ TYPE_SEVERITY = {
 }
 TYPE_FROM_SEVERITY = ['info', 'warning', 'error']
 getMostSevereAnnotationType = (arr) ->
-  result = TYPE_FROM_SEVERITY[Math.max.apply(this, arr.map((x) -> TYPE_SEVERITY[x.type]))]
-  console.log 'annotation type', result
-  return result
+  TYPE_FROM_SEVERITY[Math.max.apply(this, arr.map((x) -> TYPE_SEVERITY[x.type]))]
 
 Editor::findLineNumberAtCoordinate = (coord) ->
   treeView = @view.getViewNodeFor @tree


### PR DESCRIPTION
Add methods to Droplet to mimic Ace editor gutter decoration functionality. Changes from existing behavior:
 - Droplet now has `setBreakpoint`, `clearBreakpoint`, `clearBreakpoints`, `getBreakpoints`, and `setAnnotations`, with behavior identical to Ace. Droplet will set all of these for itself when called and will also set them in its corresponding Ace editor.
 - Droplet's `guttermousemove` now also fires when Ace's fires
 - Droplet annotation texts can be read with a title-text
 - Droplet line numbers are now on top and can recieve mouseover events directly
 - Droplet annotation glyphs are centered vertically on lines