### PR TITLE
Attempt to fix copy-paste error by forcing cursor into correct position

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -4384,7 +4384,10 @@ hook 'populate', 1, ->
         blocks = @mode.parse str
 
         @addMicroUndoOperation 'CAPTURE_POINT'
-        if @lassoSegment?
+        if @lassoSegment? and @inTree(@lassoSegment)
+          # Make sure the cursor is outside the lasso segment
+          # (although it should be already)
+          @moveCursorTo @lassoSegment.end.nextVisibleToken(), true
           @addMicroUndoOperation new PickUpOperation @lassoSegment
           @spliceOut @lassoSegment; @lassoSegment = null
 


### PR DESCRIPTION
I think that the copy-paste bug some people are seeing has to do with the cursor being in the wrong position when we do a paste. This PR will force the cursor into the correct position before a paste is done.