### PR TITLE
Dropdown visuals: scroll auto and min-width to socket

### DIFF
--- a/css/droplet.css
+++ b/css/droplet.css
@@ -252,7 +252,7 @@
 }
 .droplet-dropdown-item {
   cursor: pointer;
-  padding-right: 17px; /* To make room for the scrollbar (17px is the width on most browsers) */
+  padding-right: 5px;
 }
 .droplet-dropdown-item:hover {
   background-color: #DDD;

--- a/css/droplet.css
+++ b/css/droplet.css
@@ -247,11 +247,12 @@
   z-index: 10000;
   border: 1px solid #DDD;
   border-radius: 2px;
-  overflow-y: scroll;
+  overflow-y: auto;
   overflow-x: hidden;
 }
 .droplet-dropdown-item {
   cursor: pointer;
+  padding-right: 17px; /* To make room for the scrollbar (17px is the width on most browsers) */
 }
 .droplet-dropdown-item:hover {
   background-color: #DDD;

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -24,6 +24,7 @@ CURSOR_WIDTH_DECREASE = 3
 CURSOR_HEIGHT_DECREASE = 2
 CURSOR_UNFOCUSED_OPACITY = 0.5
 DEBUG_FLAG = false
+DROPDOWN_SCROLLBAR_PADDING = 17
 
 ANY_DROP = helper.ANY_DROP
 BLOCK_ONLY = helper.BLOCK_ONLY
@@ -1800,6 +1801,11 @@ hook 'populate', 1, ->
 
         @redrawTextInput()
 
+        # Update the dropdown size to match
+        # the new length, if it is visible.
+        if @dropdownVisible
+          @formatDropdown()
+
 Editor::resizeAceElement = ->
   width = @wrapperElement.clientWidth
   if @showPaletteInTextMode and @paletteEnabled
@@ -2191,10 +2197,23 @@ hook 'populate', 0, ->
   @dropdownElement.className = 'droplet-dropdown'
   @wrapperElement.appendChild @dropdownElement
 
+  @dropdownVisible = false
+
+# Update the dropdown to match
+# the current text focus font and size.
+Editor::formatDropdown = ->
+  @dropdownElement.style.fontFamily = @fontFamily
+  @dropdownElement.style.fontSize = @fontSize
+  @dropdownElement.style.minWidth = @view.getViewNodeFor(@textFocus).bounds[0].width
+
 Editor::showDropdown = ->
   if @textFocus.hasDropdown()
+    @dropdownVisible = true
+
     @dropdownElement.innerHTML = ''
     @dropdownElement.style.display = 'inline-block'
+
+    @formatDropdown()
 
     # Closure the text focus; dropdown should work
     # even after unfocused
@@ -2204,10 +2223,8 @@ Editor::showDropdown = ->
       div.innerHTML = el.display
       div.className = 'droplet-dropdown-item'
 
-      # Match fonts
-      div.style.fontFamily = @fontFamily
-      div.style.fontSize = @fontSize
       div.style.paddingLeft = helper.DROPDOWN_ARROW_WIDTH
+      div.style.paddingRight = DROPDOWN_SCROLLBAR_PADDING
 
       setText = (text) =>
         # Attempting to populate the socket after the dropdown has closed should no-op
@@ -2233,6 +2250,7 @@ Editor::showDropdown = ->
     @dropdownElement.style.minWidth = location.width + 'px'
 
 Editor::hideDropdown= ->
+  @dropdownVisible = false
   @dropdownElement.style.display = 'none'
 
 hook 'dblclick', 0, (point, event, state) ->

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -2210,6 +2210,8 @@ Editor::showDropdown = ->
   if @textFocus.hasDropdown()
     @dropdownVisible = true
 
+    dropdownItems = []
+
     @dropdownElement.innerHTML = ''
     @dropdownElement.style.display = 'inline-block'
 
@@ -2223,8 +2225,9 @@ Editor::showDropdown = ->
       div.innerHTML = el.display
       div.className = 'droplet-dropdown-item'
 
+      dropdownItems.push div
+
       div.style.paddingLeft = helper.DROPDOWN_ARROW_WIDTH
-      div.style.paddingRight = DROPDOWN_SCROLLBAR_PADDING
 
       setText = (text) =>
         # Attempting to populate the socket after the dropdown has closed should no-op
@@ -2243,11 +2246,24 @@ Editor::showDropdown = ->
           setText(el.text)
       @dropdownElement.appendChild div
 
-    location = @view.getViewNodeFor(@textFocus).bounds[0]
+      @dropdownElement.style.top = '-9999px'
+      @dropdownElement.style.left = '-9999px'
 
-    @dropdownElement.style.top = location.y + @fontSize - @scrollOffsets.main.y + 'px'
-    @dropdownElement.style.left = location.x - @scrollOffsets.main.x + @dropletElement.offsetLeft + @mainCanvas.offsetLeft + 'px'
-    @dropdownElement.style.minWidth = location.width + 'px'
+    # Wait for a render. Then,
+    # if the div is scrolled vertically, add
+    # some padding on the right. After checking for this,
+    # move the dropdown element into position
+    setTimeout (=>
+      if @dropdownElement.offsetHeight < @dropdownElement.scrollHeight
+        for el in dropdownItems
+          el.style.paddingRight = DROPDOWN_SCROLLBAR_PADDING
+
+      location = @view.getViewNodeFor(@textFocus).bounds[0]
+
+      @dropdownElement.style.top = location.y + @fontSize - @scrollOffsets.main.y + 'px'
+      @dropdownElement.style.left = location.x - @scrollOffsets.main.x + @dropletElement.offsetLeft + @mainCanvas.offsetLeft + 'px'
+      @dropdownElement.style.minWidth = location.width + 'px'
+    ), 0
 
 Editor::hideDropdown= ->
   @dropdownVisible = false


### PR DESCRIPTION
Two changes to the way the dropdown is shown:
  - Added 17 pixels of padding to the right and changed to `scroll:auto`. We had previously not done this because the scrollbar could sometimes cover up some text.
  - Set `min-width` to the size of the text input the dropdown is attached to, and update this when the width changes.