### PR TITLE
Support for non-editable dropdown sockets

### DIFF
--- a/EMBEDDING.md
+++ b/EMBEDDING.md
@@ -166,6 +166,16 @@ functions: {
         1: function() {
           return ['red', 'blue'];
         }
+
+        // With either of these, you can specify
+        // that the socket should be only editable by dropdown
+        // (no typing) with "dropdownOnly":
+        2: {
+          dropdownOnly: true,
+          options: function() {
+            return ['red', 'blue']
+          }
+        }
       }
     }
 },

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -120,6 +120,7 @@ module.exports = (grunt) ->
       testserver:
         options:
           hostname: '0.0.0.0'
+          port: 8001
           middleware: serveNoDottedFiles
       qunitserver:
         options:
@@ -190,7 +191,7 @@ module.exports = (grunt) ->
 
       lrserver = livereload()
 
-      lrserver.listen 35729, ->
+      lrserver.listen 35730, ->
         console.log 'Livereload server listening on 35729'
 
       w.on 'update', ->

--- a/example/example.html
+++ b/example/example.html
@@ -69,6 +69,6 @@
     <script src="../dist/droplet-full.js"></script>
 
     <script src="example.coffee" type="text/coffeescript"></script>
-    <script src="//localhost:35729/livereload.js"></script>
+    <script src="//localhost:35730/livereload.js"></script>
   </body>
 </html>

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -1293,7 +1293,7 @@ hook 'mouseup', 1, (point, event, state) ->
         # If what we've dropped has a socket in it,
         # focus it.
         head = @draggingBlock.start
-        until head.type is 'socketStart' and head.container.isDroppable() or head is @draggingBlock.end
+        until head.type is 'socketStart' and head.container.editable() or head is @draggingBlock.end
           head = head.next
 
         if head.type is 'socketStart'
@@ -2089,7 +2089,7 @@ Editor::populateSocket = (socket, string) ->
 Editor::hitTestTextInput = (point, block) ->
   head = block.start
   while head?
-    if head.type is 'socketStart' and head.next.type in ['text', 'socketEnd'] and
+    if head.type is 'socketStart' and head.container.isDroppable() and
         @view.getViewNodeFor(head.container).path.contains point
       return head.container
     head = head.next
@@ -2155,12 +2155,13 @@ hook 'mousedown', 2, (point, event, state) ->
 
   if hitTestResult?
     unless hitTestResult is @textFocus
-      @setTextInputFocus hitTestResult
-      @redrawMain()
+      if hitTestResult.editable()
+        @setTextInputFocus hitTestResult
+        @redrawMain()
 
       if hitTestResult.hasDropdown() and
           mainPoint.x - @view.getViewNodeFor(hitTestResult).bounds[0].x < helper.DROPDOWN_ARROW_WIDTH
-        @showDropdown()
+        @showDropdown hitTestResult
 
       @textInputSelecting = false
 
@@ -2192,46 +2193,44 @@ hook 'populate', 0, ->
   @dropdownElement.className = 'droplet-dropdown'
   @wrapperElement.appendChild @dropdownElement
 
-Editor::showDropdown = ->
-  if @textFocus.hasDropdown()
-    @dropdownElement.innerHTML = ''
-    @dropdownElement.style.display = 'inline-block'
+Editor::showDropdown = (socket = @textFocus) ->
+  @dropdownElement.innerHTML = ''
+  @dropdownElement.style.display = 'inline-block'
 
-    # Closure the text focus; dropdown should work
-    # even after unfocused
-    textFocus = @textFocus
-    for el, i in @textFocus.dropdown() then do (el) =>
-      div = document.createElement 'div'
-      div.innerHTML = el.display
-      div.className = 'droplet-dropdown-item'
+  # Closure the text focus; dropdown should work
+  # even after unfocused
+  for el, i in socket.dropdown.generate() then do (el) =>
+    div = document.createElement 'div'
+    div.innerHTML = el.display
+    div.className = 'droplet-dropdown-item'
 
-      # Match fonts
-      div.style.fontFamily = @fontFamily
-      div.style.fontSize = @fontSize
-      div.style.paddingLeft = helper.DROPDOWN_ARROW_WIDTH
+    # Match fonts
+    div.style.fontFamily = @fontFamily
+    div.style.fontSize = @fontSize
+    div.style.paddingLeft = helper.DROPDOWN_ARROW_WIDTH
 
-      setText = (text) =>
-        # Attempting to populate the socket after the dropdown has closed should no-op
-        return if @dropdownElement.style.display == 'none'
+    setText = (text) =>
+      # Attempting to populate the socket after the dropdown has closed should no-op
+      return if @dropdownElement.style.display == 'none'
 
-        @populateSocket @textFocus, text
-        @hiddenInput.value = text
+      @populateSocket socket, text
+      @hiddenInput.value = text
 
-        @redrawMain()
-        @hideDropdown()
+      @redrawMain()
+      @hideDropdown()
 
-      div.addEventListener 'mouseup', ->
-        if el.click
-          el.click(setText)
-        else
-          setText(el.text)
-      @dropdownElement.appendChild div
+    div.addEventListener 'mouseup', ->
+      if el.click
+        el.click(setText)
+      else
+        setText(el.text)
+    @dropdownElement.appendChild div
 
-    location = @view.getViewNodeFor(@textFocus).bounds[0]
+  location = @view.getViewNodeFor(socket).bounds[0]
 
-    @dropdownElement.style.top = location.y + @fontSize - @scrollOffsets.main.y + 'px'
-    @dropdownElement.style.left = location.x - @scrollOffsets.main.x + @dropletElement.offsetLeft + @mainCanvas.offsetLeft + 'px'
-    @dropdownElement.style.minWidth = location.width + 'px'
+  @dropdownElement.style.top = location.y + @fontSize - @scrollOffsets.main.y + 'px'
+  @dropdownElement.style.left = location.x - @scrollOffsets.main.x + @dropletElement.offsetLeft + @mainCanvas.offsetLeft + 'px'
+  @dropdownElement.style.minWidth = location.width + 'px'
 
 Editor::hideDropdown= ->
   @dropdownElement.style.display = 'none'
@@ -2248,11 +2247,12 @@ hook 'dblclick', 0, (point, event, state) ->
   # If they have clicked a socket,
   # focus it, and
   unless hitTestResult is @textFocus
-    @setTextInputFocus null
-    @redrawMain()
-    hitTestResult = @hitTestTextInput mainPoint, @tree
+    if hitTestResult.editable()
+      @setTextInputFocus null
+      @redrawMain()
+      hitTestResult = @hitTestTextInput mainPoint, @tree
 
-  if hitTestResult?
+  if hitTestResult? and hitTestResult.editable()
     @setTextInputFocus hitTestResult
     @redrawMain()
 
@@ -2700,7 +2700,7 @@ Editor::moveCursorHorizontally = (direction) ->
         break
 
     if head.type is 'socketStart' and
-        (head.next.type is 'text' or head.next is head.container.end)
+       head.container.editable()
       # Avoid problems with reparses by getting text offset location
       # of the given socket before reparsing and recovering it afterward.
       if @textFocus?
@@ -2792,7 +2792,7 @@ Editor::getSocketAtChar = (chars) ->
   charsCounted = 0
 
   until charsCounted >= chars and head.type is 'socketStart' and
-      (head.next.type is 'text' or head.next is head.container.end)
+      head.container.isDroppable()
     if head.type is 'text' then charsCounted += head.value.length
 
     head = head.next
@@ -2806,7 +2806,7 @@ hook 'keydown', 0, (event, state) ->
     else head = @cursor
 
     until (not head?) or head.type is 'socketEnd' and
-        (head.container.start.next.type is 'text' or head.container.start.next is head.container.end)
+        head.container.editble()
       head = head.prev
 
     if head?
@@ -2828,7 +2828,7 @@ hook 'keydown', 0, (event, state) ->
     else head = @cursor
 
     until (not head?) or head.type is 'socketStart' and
-        (head.container.start.next.type is 'text' or head.container.start.next is head.container.end)
+        head.container.editable()
       head = head.next
     if head?
       # Avoid problems with reparses by getting text offset location

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -2159,8 +2159,8 @@ hook 'mousedown', 2, (point, event, state) ->
         @setTextInputFocus hitTestResult
         @redrawMain()
 
-      if hitTestResult.hasDropdown() and
-          mainPoint.x - @view.getViewNodeFor(hitTestResult).bounds[0].x < helper.DROPDOWN_ARROW_WIDTH
+      if hitTestResult.hasDropdown() and ((not hitTestResult.editable()) or
+          mainPoint.x - @view.getViewNodeFor(hitTestResult).bounds[0].x < helper.DROPDOWN_ARROW_WIDTH)
         @showDropdown hitTestResult
 
       @textInputSelecting = false

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -762,6 +762,8 @@ exports.Socket = class Socket extends Container
 
   hasDropdown: -> @dropdown? and @isDroppable()
 
+  editable: -> (not (@dropdown? and @dropdown.exclusive)) and @isDroppable()
+
   isDroppable: -> @start.next is @end or @start.next.type is 'text'
 
   _cloneEmpty: -> new Socket @precedence, @handwritten, @classes, @dropdown

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -762,7 +762,7 @@ exports.Socket = class Socket extends Container
 
   hasDropdown: -> @dropdown? and @isDroppable()
 
-  editable: -> (not (@dropdown? and @dropdown.exclusive)) and @isDroppable()
+  editable: -> (not (@dropdown? and @dropdown.dropdownOnly)) and @isDroppable()
 
   isDroppable: -> @start.next is @end or @start.next.type is 'text'
 

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -36,11 +36,20 @@ exports.Parser = class Parser
         return x
     for key, val of @opts.functions
       for index, options of val.dropdown then do (options) =>
-        @opts.functions[key].dropdown[index] = ->
-          if (typeof options is 'function')
-            return options().map convertFunction
-          else
-            return options.map convertFunction
+        exclusive = false
+        if options.exclusive?
+          exclusive = options.exclusive
+          options = options.options
+
+        @opts.functions[key].dropdown[index] = {
+          exclusive: exclusive
+          options: options
+          generate: ->
+            if (typeof options is 'function')
+              return options().map convertFunction
+            else
+              return options.map convertFunction
+        }
     # Text can sometimes be subject to change
     # when doing error recovery, so keep a record of
     # the original text.


### PR DESCRIPTION
In `modeOptions`, embedders can now specify
```
dropdown: {
  "0": {
    exclusive: true,
    options: ["hello"]
  }
}
```

The change is backwards-compatible.