### PR TITLE
add newline when drag/dropping block at front of line

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -1217,8 +1217,8 @@ hook 'mouseup', 1, (point, event, state) ->
         indentation = currentIndentation
         suffix = ''
 
-        if currentIndentation.length == line.length
-          # line is whitespace only.
+        if currentIndentation.length == line.length or currentIndentation.length == pos.column
+          # line is whitespace only or we're inserting at the beginning of a line
           # Append with a newline
           suffix = '\n' + indentation
         else if pos.column == line.length


### PR DESCRIPTION
![indentation](https://cloud.githubusercontent.com/assets/1767466/8237474/7c004a7a-15a4-11e5-8977-6b9535a3b314.gif)

When we drag a block to the front of a line, we should add a new line + indentation to the end of the block.