### PR TITLE
Beginner mode for "for" loops

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -224,7 +224,10 @@ exports.Editor = class Editor
 
     # Instantiate an ICE editor view
     @view = new view.View extend_ @standardViewSettings, respectEphemeral: true
-    @paletteView = new view.View extend_ @standardViewSettings, {showDropdowns: false, respectEphemeral: true}
+    @paletteView = new view.View extend_ @standardViewSettings, {
+      showDropdowns: @options.showDropdownInPalette ? false
+      respectEphemeral: true
+    }
     @dragView = new view.View extend_ @standardViewSettings, respectEphemeral: false
 
     boundListeners = []

--- a/src/view.coffee
+++ b/src/view.coffee
@@ -29,6 +29,7 @@ DROPDOWN_ARROW_HEIGHT = 8
 DROP_TRIANGLE_COLOR = '#555'
 
 DEFAULT_OPTIONS =
+  showDropdowns: true
   padding: 5
   indentWidth: 10
   indentTongueHeight: 10
@@ -1749,14 +1750,18 @@ exports.View = class View
         dimension.width =
             Math.max(dimension.width, @view.opts.minSocketWidth)
 
-        if @model.hasDropdown()
+        if @model.hasDropdown() and @view.opts.showDropdowns
           dimension.width += helper.DROPDOWN_ARROW_WIDTH
 
       return null
 
     # ## computeBoundingBoxX (SocketViewNode)
     computeBoundingBoxX: (left, line) ->
-      super left, line, if @model.hasDropdown() then helper.DROPDOWN_ARROW_WIDTH else 0
+      super left, line, (
+        if @model.hasDropdown() and @view.opts.showDropdowns
+          helper.DROPDOWN_ARROW_WIDTH
+        else 0
+      )
 
     # ## computeGlue
     # Sockets have one exception to normal glue spacing computation:
@@ -1813,7 +1818,7 @@ exports.View = class View
     # ## drawSelf (SocketViewNode)
     drawSelf: (ctx) ->
       super
-      if @model.hasDropdown()
+      if @model.hasDropdown() and @view.opts.showDropdowns
         ctx.beginPath()
         ctx.fillStyle = DROP_TRIANGLE_COLOR
         ctx.moveTo @bounds[0].x + helper.DROPDOWN_ARROW_PADDING, @bounds[0].y + (@bounds[0].height - DROPDOWN_ARROW_HEIGHT) / 2

--- a/test/src/jstest.coffee
+++ b/test/src/jstest.coffee
@@ -455,3 +455,45 @@ asyncTest 'JS Elif', ->
       helper.xmlPrettyPrint(expectedSerialization),
       'Combines if-else')
   start()
+
+asyncTest 'JS Elif', ->
+  customJS = new JavaScript({
+    categories: {loops: {color: 'green', beginner: true}}
+  })
+  customSerialization = customJS.parse(
+    '''
+    for (var i = 0; i < 10; i++) {
+      go();
+    }
+    '''
+  ).serialize()
+  expectedSerialization =
+    '<segment' +
+    '  isLassoSegment="false"' +
+    '><block' +
+    '  precedence="0"' +
+    '  color="green"' +
+    '  socketLevel="0"' +
+    '  classes="ends-with-brace block-only ForStatement"' +
+    '>for (var i = 0; i &amp;lt; <socket' +
+    '  precedence="0"' +
+    '  handwritten="false"' +
+    '  classes=""' +
+    '>10</socket>; i++) {<indent' +
+    '  prefix="  "' +
+    '  classes=""' +
+    '>\n<block' +
+    '  precedence="2"' +
+    '  color="blue"' +
+    '  socketLevel="0"' +
+    '  classes="CallExpression any-drop"' +
+    '><socket' +
+    '  precedence="100"' +
+    '  handwritten="false"' +
+    '  classes=""' +
+    '>go</socket>();</block></indent>\n}</block></segment>'
+  strictEqual(
+      helper.xmlPrettyPrint(customSerialization),
+      helper.xmlPrettyPrint(expectedSerialization),
+      'Combines if-else')
+  start()


### PR DESCRIPTION
Embedders can now specify beginner mode with a flag in the "categories" option:
```javascript
//...
modeOptions: {
  categories: {
    loops: {
      color: "green",
      beginner: true
    }
  }
}
//...
```

This will make for loops of this form mark only "b":
```javascript
for (var i = 0; i < b; i++) {
  //...
}
```

It is currently very picky about which loops it chooses to do this with; they must be exactly of the form `(/*var*/ a = x; a < b; a++)` and `a` must be the same identifier in all three expressions.