### PR TITLE
Beginner mode for "for" loops

### DIFF
--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -615,11 +615,21 @@ JavaScriptParser.drop = (block, context, pred) ->
 
   return helper.DISCOURAGE
 
+# Check to see if a "for" loop is standard, for beginner mode.
+# We will simplify any loop of the form:
+# ```
+# for (var i = X; i < Y; i++) {
+#   // etc...
+# }
+# `
+# Where "var" is optional and "i++" can be pre- or postincrement.
 isStandardForLoop = (node) ->
   unless node.init? and node.test? and node.update?
     return false
 
-  # A standard for loop starts with "var a =" or "a = "
+  # A standard for loop starts with "var a =" or "a = ".
+  # Determine the variable name so that we can check against it
+  # in the other two expression.
   if node.init.type is 'VariableDeclaration'
     variableName = node.init.declarations[0].id.name
   else if node.init.type is 'AssignmentExpression' and

--- a/test/src/jstest.coffee
+++ b/test/src/jstest.coffee
@@ -455,3 +455,45 @@ asyncTest 'JS Elif', ->
       helper.xmlPrettyPrint(expectedSerialization),
       'Combines if-else')
   start()
+
+asyncTest 'JS Elif', ->
+  customJS = new JavaScript({
+    categories: {loops: {color: 'green', beginner: true}}
+  })
+  customSerialization = customJS.parse(
+    '''
+    for (var i = 0; i < 10; i++) {
+      go();
+    }
+    '''
+  ).serialize()
+  expectedSerialization =
+    '<segment' +
+    '  isLassoSegment="false"' +
+    '><block' +
+    '  precedence="0"' +
+    '  color="green"' +
+    '  socketLevel="0"' +
+    '  classes="ends-with-brace block-only ForStatement"' +
+    '>for (var i = 0; i &amp;lt; <socket' +
+    '  precedence="0"' +
+    '  handwritten="false"' +
+    '  classes=""' +
+    '>10</socket>; i++) {<indent' +
+    '  prefix="  "' +
+    '  classes=""' +
+    '>\n<block' +
+    '  precedence="2"' +
+    '  color="blue"' +
+    '  socketLevel="0"' +
+    '  classes="CallExpression any-drop"' +
+    '><socket' +
+    '  precedence="100"' +
+    '  handwritten="false"' +
+    '  classes=""' +
+    '>go</socket>();</block></indent>\n}</block></segment>'
+  strictEqual(
+      helper.xmlPrettyPrint(customSerialization),
+      helper.xmlPrettyPrint(expectedSerialization),
+      'Combines if-else')
+  start()

--- a/test/src/jstest.coffee
+++ b/test/src/jstest.coffee
@@ -456,7 +456,7 @@ asyncTest 'JS Elif', ->
       'Combines if-else')
   start()
 
-asyncTest 'JS Elif', ->
+asyncTest 'JS beginner mode loops', ->
   customJS = new JavaScript({
     categories: {loops: {color: 'green', beginner: true}}
   })


### PR DESCRIPTION
Embedders can now specify beginner mode with a flag in the "categories" option:
```javascript
//...
modeOptions: {
  categories: {
    loops: {
      color: "green",
      beginner: true
    }
  }
}
//...
```

This will make for loops of this form mark only "b":
```javascript
for (var i = 0; i < b; i++) {
  //...
}
```

It is currently very picky about which loops it chooses to do this with; they must be exactly of the form `(/*var*/ a = x; a < b; a++)` and `a` must be the same identifier in all three expressions.