### PR TITLE
Extra parameter 'next' in drop callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,12 +197,13 @@ MyParser.parens = (leading, trailing, node, context) ->
 # Text to fill in an empty socket when switching modes:
 MyParser.empty = "blarg"
 
-MyParser.drop = (block, context, preceding) ->
+MyParser.drop = (block, context, preceding, succeeding) ->
   # block: the block that user is dragging
   # context: the place the user is dropping that block into
   # preceding: if in sequence, the block immediately before
+  # succeeding: if in sequence, the block immediately after
 
-  # block, context, and preceding will have
+  # block, context, preceding and succeeding will have
   # properties `classes` (from when you created the block),
   # `precedence`, and `type` ('block', 'socket', 'indent', or 'segment')
   if allowedIn(block, context)

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -1114,14 +1114,34 @@ Editor::getAcceptLevel = (drag, drop) ->
     if drag.type is 'segment'
       return helper.FORBID
     else
-      return @mode.drop drag.getReader(), drop.getReader(), null
+      return @mode.drop drag.getReader(), drop.getReader(), null, null
   else if drop.type is 'block'
     if drop.visParent().type is 'socket'
       return helper.FORBID
     else
-      return @mode.drop drag.getReader(), drop.visParent().getReader(), drop
+      #Find next sibling which is a compound block(Not Text/NewLine/Cursor)
+      next = drop.end.next
+      while not next.container
+        next = next.next
+      #If sibling is Parent, we don't have a sibling
+      if next.container is drop.visParent()
+        next = null
+      #Else get reader of the sibling
+      else
+        next = next.container.getReader()
+      return @mode.drop drag.getReader(), drop.visParent().getReader(), drop.getReader(), next
   else
-    return @mode.drop drag.getReader(), drop.getReader(), drop.getReader()
+    #If drop is indent/segment, `next` is the first child of the context
+    next = drop.start.next
+    while not next.container
+      next = next.next
+    #If we reached the context itself, the context doesnt have any children
+    if next.container is drop
+        next = null
+    #Else get reader of the first child
+    else
+      next = next.container.getReader()
+    return @mode.drop drag.getReader(), drop.getReader(), drop.getReader(), next
 
 # On mousemove, if there is a dragged block, we want to
 # translate the drag canvas into place,

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -1119,29 +1119,11 @@ Editor::getAcceptLevel = (drag, drop) ->
     if drop.visParent().type is 'socket'
       return helper.FORBID
     else
-      #Find next sibling which is a compound block(Not Text/NewLine/Cursor)
-      next = drop.end.next
-      while not next.container
-        next = next.next
-      #If sibling is Parent, we don't have a sibling
-      if next.container is drop.visParent()
-        next = null
-      #Else get reader of the sibling
-      else
-        next = next.container.getReader()
-      return @mode.drop drag.getReader(), drop.visParent().getReader(), drop.getReader(), next
+      next = drop.nextSibling()
+      return @mode.drop drag.getReader(), drop.visParent().getReader(), drop.getReader(), if next then next.getReader() else null
   else
-    #If drop is indent/segment, `next` is the first child of the context
-    next = drop.start.next
-    while not next.container
-      next = next.next
-    #If we reached the context itself, the context doesnt have any children
-    if next.container is drop
-        next = null
-    #Else get reader of the first child
-    else
-      next = next.container.getReader()
-    return @mode.drop drag.getReader(), drop.getReader(), drop.getReader(), next
+    next = drop.firstChild()
+    return @mode.drop drag.getReader(), drop.getReader(), drop.getReader(), if next then next.getReader() else null
 
 # On mousemove, if there is a dragged block, we want to
 # translate the drag canvas into place,

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -97,6 +97,16 @@ exports.Container = class Container
   # with the same metadata.
   _cloneEmpty: -> new Container()
 
+  # Utility function to first block
+  # child if an indent/segment
+  _firstChild: ->
+    head = @start.next
+    while head isnt @end
+      if head instanceof StartToken
+        return head.container
+      head = head.next
+    return null
+
   getReader: ->
     {
       id: @id
@@ -725,6 +735,15 @@ exports.Block = class Block extends Container
 
     super
 
+  nextSibling: ->
+    head = @end.next
+    parent = head.visParent()
+    while head and head.container isnt parent
+      if head instanceof StartToken
+        return head.container
+      head = head.next
+    return null
+
   _cloneEmpty: ->
     clone = new Block @precedence, @color, @socketLevel, @classes
     clone.currentlyParenWrapped = @currentlyParenWrapped
@@ -809,6 +828,8 @@ exports.Indent = class Indent extends Container
 
     super
 
+  firstChild: -> return @_firstChild()
+
   _cloneEmpty: -> new Indent @prefix, @classes
   _serialize_header: -> "<indent prefix=\"#{
     @prefix
@@ -841,6 +862,8 @@ exports.Segment = class Segment extends Container
     @type = 'segment'
 
     super
+
+  firstChild: -> return @_firstChild()
 
   _cloneEmpty: -> new Segment @isLassoSegment
 

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -465,7 +465,7 @@ Parser.parens = (leading, trailing, node, context) ->
     leading '(' + leading()
     trailing trailing() + ')'
 
-Parser.drop = (block, context, pred) ->
+Parser.drop = (block, context, pred, next) ->
   if block.type is 'segment' and context.type is 'socket'
     return helper.FORBID
   else
@@ -508,4 +508,4 @@ exports.wrapParser = (CustomParser) ->
 
       return [leading, trailing]
 
-    drop: (block, context, pred) -> CustomParser.drop block, context, pred
+    drop: (block, context, pred, next) -> CustomParser.drop block, context, pred, next


### PR DESCRIPTION
Implements an extra parameter `next` in drop callback which gives information about the immediately next block, if it exists.
Can be used to ensure droppability of a block only before certain types of blocks.