### PR TITLE
Separate paletteWrapper and paletteElement.

### DIFF
--- a/css/droplet.css
+++ b/css/droplet.css
@@ -69,13 +69,18 @@
   position: absolute;
   top: 0; bottom: 0; width: 300px;
   max-width: 40%;
-  overflow: hidden;
   z-index: 257;
   -webkit-user-select: none;
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+}
+.droplet-palette-element {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
 }
 .droplet-palette-header {
   z-index: 257;

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -177,8 +177,12 @@ exports.Editor = class Editor
 
     @dropletElement.appendChild @mainCanvas
 
-    @paletteWrapper = @paletteElement = document.createElement 'div'
+    @paletteWrapper = document.createElement 'div'
     @paletteWrapper.className = 'droplet-palette-wrapper'
+
+    @paletteElement = document.createElement 'div'
+    @paletteElement.className = 'droplet-palette-element'
+    @paletteWrapper.appendChild @paletteElement
 
     # Then palette canvas
     @paletteCanvas = document.createElement 'canvas'
@@ -187,17 +191,17 @@ exports.Editor = class Editor
 
     @paletteCtx = @paletteCanvas.getContext '2d'
 
-    @paletteWrapper.appendChild @paletteCanvas
+    @paletteElement.appendChild @paletteCanvas
 
-    @paletteElement.style.position = 'absolute'
-    @paletteElement.style.left = '0px'
-    @paletteElement.style.top = '0px'
-    @paletteElement.style.bottom = '0px'
-    @paletteElement.style.width = '270px'
+    @paletteWrapper.style.position = 'absolute'
+    @paletteWrapper.style.left = '0px'
+    @paletteWrapper.style.top = '0px'
+    @paletteWrapper.style.bottom = '0px'
+    @paletteWrapper.style.width = '270px'
 
-    @dropletElement.style.left = @paletteElement.offsetWidth + 'px'
+    @dropletElement.style.left = @paletteWrapper.offsetWidth + 'px'
 
-    @wrapperElement.appendChild @paletteElement
+    @wrapperElement.appendChild @paletteWrapper
 
     do @draw.refreshFontCapital
 
@@ -342,7 +346,7 @@ exports.Editor = class Editor
 
     @dropletElement.style.height = "#{@wrapperElement.clientHeight}px"
     if @paletteEnabled
-      @dropletElement.style.left = "#{@paletteElement.offsetWidth}px"
+      @dropletElement.style.left = "#{@paletteWrapper.offsetWidth}px"
       @dropletElement.style.width = "#{@wrapperElement.clientWidth - @paletteWrapper.offsetWidth}px"
     else
       @dropletElement.style.left = "0px"
@@ -381,11 +385,6 @@ exports.Editor = class Editor
     @redrawMain()
 
   resizePalette: ->
-    ###
-    @paletteWrapper.style.height = "#{@paletteElement.offsetHeight}px"
-    @paletteWrapper.style.width = "#{@paletteElement.offsetWidth}px"
-    ###
-
     @paletteCanvas.style.top = "#{@paletteHeader.offsetHeight}px"
     @paletteCanvas.height = @paletteWrapper.offsetHeight - @paletteHeader.offsetHeight
     @paletteCanvas.width = @paletteWrapper.offsetWidth
@@ -1545,7 +1544,7 @@ hook 'populate', 0, ->
   @paletteHeader.className = 'droplet-palette-header'
 
   # Append the element.
-  @paletteWrapper.appendChild @paletteHeader
+  @paletteElement.appendChild @paletteHeader
 
   @setPalette @paletteGroups
 
@@ -1673,7 +1672,7 @@ hook 'populate', 1, ->
   @paletteHighlightPath = null
   @currentHighlightedPaletteBlock = null
 
-  @paletteWrapper.appendChild @paletteHighlightCanvas
+  @paletteElement.appendChild @paletteHighlightCanvas
 
 Editor::resizePaletteHighlight = ->
   @paletteHighlightCanvas.style.top = @paletteHeader.offsetHeight + 'px'
@@ -1823,7 +1822,7 @@ hook 'populate', 1, ->
 Editor::resizeAceElement = ->
   width = @wrapperElement.clientWidth
   if @showPaletteInTextMode and @paletteEnabled
-    width -= @paletteElement.offsetWidth
+    width -= @paletteWrapper.offsetWidth
 
   @aceElement.style.width = "#{width}px"
   @aceElement.style.height = "#{@wrapperElement.clientHeight}px"
@@ -3625,7 +3624,7 @@ hook 'populate', 2, ->
   @paletteScrollerStuffing.className = 'droplet-palette-scroller-stuffing'
 
   @paletteScroller.appendChild @paletteScrollerStuffing
-  @paletteWrapper.appendChild @paletteScroller
+  @paletteElement.appendChild @paletteScroller
 
   @paletteScroller.addEventListener 'scroll', =>
     @scrollOffsets.palette.y = @paletteScroller.scrollTop


### PR DESCRIPTION
Previously these two controller members referred to the same
element.  Now they are different, one nested in the other.

Now paletteWrapper deals with the sizing of the overall palette pane
but not the clipping or the containing, and paletteElement contains
all the children and does the clipping.  This allows embedders
such as Pencil Code to decorate the palette pane by attaching elements
to paletteWrapper (such as mode- or palette-switching buttons and menus)
without interfering with the working of the palette.

This is a no-op for most users of pencil code.
