### PR TITLE
Gutter resize fix

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -4291,6 +4291,7 @@ hook 'populate', 0, ->
   @gutter.appendChild @lineNumberWrapper
 
   @gutterVersion = -1
+  @lastGutterWidth = null
 
   @lineNumberTags = {}
 
@@ -4369,7 +4370,10 @@ Editor::setAnnotations = (annotations) ->
   @redrawGutter false
 
 Editor::resizeGutter = ->
-  @gutter.style.width = @aceEditor.renderer.$gutterLayer.gutterWidth + 'px'
+  unless @lastGutterWidth is @aceEditor.renderer.$gutterLayer.gutterWidth
+    @lastGutterWidth = @aceEditor.renderer.$gutterLayer.gutterWidth
+    @gutter.style.width = @lastGutterWidth + 'px'
+    return @resize()
   @gutter.style.height = "#{Math.max(@dropletElement.offsetHeight,
     (@view.getViewNodeFor(@tree).totalBounds?.bottom?() ? 0) +
     (@options.extraBottomHeight ? @fontSize))}px"

--- a/test/test.html
+++ b/test/test.html
@@ -9,12 +9,15 @@
         height: 300px;
         width: 500px;
       }
+      #test-main {
+        height: 300px;
+        width: 500px;
+      }
     </style>
   </head>
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
   <div id="hidden">
-    <canvas id="main"></canvas>
     <div id="test-main">
     </div>
     <div id="test-palette">


### PR DESCRIPTION
Resize/reposition the main canvas when the gutter resizes to avoid this overlapping issue:
![](https://s3.amazonaws.com/uploads.hipchat.com/65395/627819/wNoTxUiiML004LH/upload.png)
