### PR TITLE
Add classes and droppability for comment blocks

### DIFF
--- a/src/languages/coffee.coffee
+++ b/src/languages/coffee.coffee
@@ -1054,6 +1054,9 @@ CoffeeScriptParser.drop = (block, context, pred) ->
   return helper.DISCOURAGE
 
 CoffeeScriptParser.parens = (leading, trailing, node, context) ->
+  # Don't attempt to paren wrap comments
+  return if '__comment__' in node.classes
+
   trailing trailing().replace /\s*,\s*$/, ''
   if context is null or context.type isnt 'socket' or
       context.precedence < node.precedence

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -555,6 +555,9 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
     @mark indentDepth, node, depth + 1, bounds
 
 JavaScriptParser.parens = (leading, trailing, node, context) ->
+  # Don't attempt to paren wrap comments
+  return if '__comment__' in node.classes
+
   if context?.type is 'socket' or
      (not context? and 'mostly-value' in node.classes or 'value-only' in node.classes) or
      'ends-with-brace' in node.classes or

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -230,6 +230,7 @@ exports.Parser = class Parser
 
     if @isComment text
       block.socketLevel = helper.BLOCK_ONLY
+      block.classes = ['__comment__', 'block-only']
 
     return block
 


### PR DESCRIPTION
Allow comment blocks to be dropped in indent contexts, and don't add parentheses or semicolons to them.