### PR TITLE
Remember socket floating

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -48,7 +48,11 @@ module.exports = (grunt) ->
 
     qunit:
       options:
-        timeout: 30000
+        timeout: 60000
+        page:
+          viewportSize:
+            width: 1000
+            height: 1000
       all:
         urls:
           (for x in grunt.file.expand('test/*.html')

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -842,7 +842,7 @@ Editor::redo = ->
   return
 
 # ## undoCapture and CapturePoint ##
-# A CapturePoint is a flag indicating that the undo stack
+# A CapturePoint is a sentinel indicating that the undo stack
 # should stop when the user presses Ctrl+Z or Ctrl+Y. Each CapturePoint
 # also remembers the @rememberedSocket state at the time it was placed,
 # to preserved remembered socket contents across undo and redo.
@@ -857,6 +857,16 @@ class CapturePoint
 # ================================
 
 hook 'populate', 7, ->
+  # ## rememberedSockets ##
+  # This is an array with pair elements mapping locations of sockets
+  # to old text values, for when users drop a block into a socket and then pull
+  # it back out again. All the mutation operations (spliceIn, spliceOut, replace)
+  # update these locations to attempt to make sure the locations point to the same sockets,
+  # and the Controller will also attempt to bring the locations with a dragged block
+  # if they are inside it.
+  #
+  # A snapshot of this array is taken every CapturePoint in the undo stack and restored
+  # when the undo stack reaches this point, to persist this effect across undo and redo.
   @rememberedSockets = []
 
 Editor::getPreserves = (dropletDocument) ->

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -1483,7 +1483,7 @@ hook 'mouseup', 1, (point, event, state) ->
 
 Editor::spliceRememberedSocketOffsets = (block) ->
   if block.getDocument()?
-    blockBegin = block.getLocation().count
+    blockBegin = block.start.getLocation().count
     offsets = []
     newRememberedSockets = []
     for el, i in @rememberedSockets

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -852,7 +852,7 @@ Editor::replace = (before, after, updates) ->
   dropletDocument = before.start.getDocument()
   if dropletDocument?
     operation = dropletDocument.replace before, after, updates.concat(@getPreserves(dropletDocument))
-    @pushUndo {operation, document: @getDocuments().indexOf(dropletDocument)}
+    @pushUndo {operation, document: @documentIndex(dropletDocument)}
     @correctCursor()
     return operation
   else
@@ -2408,7 +2408,7 @@ Editor::setCursor = (destination, validate = (-> true), direction = 'after') ->
 
   # If the cursor was at a text input, reparse the old one
   if @cursorAtSocket() and not @cursor.is(destination)
-    @reparse @getCursor(), (if destination.document is @cursor.document then [destination.location] else [])
+    @reparse @getCursor(), null, (if destination.document is @cursor.document then [destination.location] else [])
     @hiddenInput.blur()
     @dropletElement.focus()
 

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -99,6 +99,9 @@ exports.List = class List
     @id = ++_id
 
   contains: (token) ->
+    if token instanceof Container
+      token = token.start
+
     head = @start
     until head is @end
       if head is token

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -85,6 +85,7 @@ class Operation
     list: @list.stringify()
     start: @start.toString()
     end: @end.toString()
+    type: @type
   })
 
 class ReplaceOperation
@@ -93,6 +94,16 @@ class ReplaceOperation
         @afterStart, @after, @afterEnd
       ) ->
     @type = 'replace'
+
+  toString: -> JSON.stringify({
+    beforeStart: @beforeStart.toString()
+    before: @before.stringify()
+    beforeEnd: @beforeEnd.toString()
+    afterStart: @afterStart.toString()
+    after: @after.stringify()
+    afterEnd: @afterEnd.toString()
+    type: @type
+  })
 
 exports.List = class List
   constructor: (@start, @end) ->
@@ -870,6 +881,8 @@ exports.Location = class Location
     unless other instanceof Location
       other = other.getLocation()
     return other.count is @count and other.type is @type
+
+  clone: -> new Location @count, @type
 
 exports.TextLocation = class TextLocation
   constructor: (

--- a/test/src/uitest.coffee
+++ b/test/src/uitest.coffee
@@ -5,7 +5,6 @@ draw = require '../../src/draw.coffee'
 droplet = require '../../dist/droplet-full.js'
 seedrandom = require 'seedrandom'
 
-console.log window.innerWidth, window.innerHeight
 `
 // Mouse event simluation function
 function simulate(type, target, options) {

--- a/test/src/uitest.coffee
+++ b/test/src/uitest.coffee
@@ -127,7 +127,7 @@ asyncTest 'Controller: palette block expansion', ->
   equal(editor.getValue().trim(), 'pen red\na1 = b\na2 = b')
   start()
 
-asyncTest 'Controller: reparse fallback', ->
+asyncTest 'Controller: reparse and undo reparse', ->
   states = []
   document.getElementById('test-main').innerHTML = ''
   varcount = 0

--- a/test/src/uitest.coffee
+++ b/test/src/uitest.coffee
@@ -578,6 +578,7 @@ asyncTest 'Controller: remembered sockets', ->
           fd 10
           bk 10\n
       ''')
+      start()
     )
   ]
 

--- a/test/src/uitest.coffee
+++ b/test/src/uitest.coffee
@@ -426,6 +426,162 @@ performDragOperation = (editor, drag, cb) ->
     setTimeout cb, 0
   ), 0
 
+pickUpLocation = (editor, document, location) ->
+  block = editor.getDocument(document).getFromTextLocation(location)
+  bound = editor.view.getViewNodeFor(block).bounds[0]
+  simulate('mousedown', editor.mainScrollerStuffing, {
+    dx: bound.x + editor.gutter.offsetWidth + 5,
+    dy: bound.y + 5
+  })
+  simulate('mousemove', editor.dragCover, {
+    location: editor.mainCanvas
+    dx: bound.x + editor.gutter.offsetWidth + 10,
+    dy: bound.y + 10
+  })
+
+dropLocation = (editor, document, location) ->
+  block = editor.getDocument(document).getFromTextLocation(location)
+  blockView = editor.view.getViewNodeFor block
+  simulate('mousemove', editor.dragCover, {
+    location: editor.mainCanvas
+    dx: blockView.dropPoint.x + 5,
+    dy: blockView.dropPoint.y + 5
+  })
+  simulate('mouseup', editor.mainScroller, {
+    dx: blockView.dropPoint.x + 5
+    dy: blockView.dropPoint.y + 5
+  })
+
+executeAsyncSequence = (sequence, i = 0) ->
+  if i < sequence.length
+    sequence[i]()
+    setTimeout (->
+      executeAsyncSequence sequence, i + 1
+    ), 0
+
+asyncTest 'Controller: remembered sockets', ->
+  document.getElementById('test-main').innerHTML = ''
+  window.editor = editor = new droplet.Editor(document.getElementById('test-main'), {
+    mode: 'coffeescript',
+    modeOptions:
+      functions:
+        fd: {command: true, value: false}
+        bk: {command: true, value: false}
+    palette: [
+      {
+        name: 'Blocks'
+        blocks: [
+          {block: 'a is b'}
+          {block: 'fd 10'}
+          {block: 'bk 10'}
+          {block: '''
+          for i in [0..10]
+            ``
+          '''}
+          {block: '''
+          if a is b
+            ``
+          '''}
+        ]
+      }
+    ]
+  })
+
+  editor.setEditorState(true)
+  editor.setValue('''
+  for i in [0..10]
+    if i % 2 is 0
+      fd 10
+    else
+      bk 10
+  ''')
+
+  executeAsyncSequence [
+    (->
+      pickUpLocation editor, 0, {
+        row: 0
+        col: 9
+        type: 'block'
+      }
+      dropLocation editor, 0, {
+        row: 2
+        col: 7
+        type: 'socket'
+      }
+    ), (->
+      equal(editor.getValue(), '''
+      for i in ``
+        if i % 2 is 0
+          fd [0..10]
+        else
+          bk 10\n
+      ''')
+    ), (->
+      pickUpLocation editor, 0, {
+        row: 2
+        col: 4
+        type: 'block'
+      }
+      dropLocation editor, 0, {
+        row: 3
+        col: 6
+        type: 'indent'
+      }
+    ), (->
+      pickUpLocation editor, 0, {
+        row: 4
+        col: 7
+        type: 'block'
+      }
+      dropLocation editor, 0, {
+        row: 0
+        col: 9
+        type: 'socket'
+      }
+    ), (->
+      equal(editor.getValue(), '''
+      for i in [0..10]
+        if i % 2 is 0
+          ``
+        else
+          fd 10
+          bk 10\n
+      ''')
+    ), (->
+      editor.undo()
+    ), (->
+      equal(editor.getValue(), '''
+      for i in ``
+        if i % 2 is 0
+          ``
+        else
+          fd [0..10]
+          bk 10\n
+      ''')
+    ), (->
+      pickUpLocation editor, 0, {
+        row: 4
+        col: 7
+        type: 'block'
+      }
+      dropLocation editor, 0, {
+        row: 0
+        col: 9
+        type: 'socket'
+      }
+    ), (->
+      equal(editor.getValue(), '''
+      for i in [0..10]
+        if i % 2 is 0
+          ``
+        else
+          fd 10
+          bk 10\n
+      ''')
+    )
+  ]
+
+
 asyncTest 'Controller: Random drag undo test', ->
   document.getElementById('test-main').innerHTML = ''
   window.editor = editor = new droplet.Editor(document.getElementById('test-main'), {

--- a/test/src/uitest.coffee
+++ b/test/src/uitest.coffee
@@ -4,6 +4,8 @@ view = require '../../src/view.coffee'
 draw = require '../../src/draw.coffee'
 droplet = require '../../dist/droplet-full.js'
 seedrandom = require 'seedrandom'
+
+console.log window.innerWidth, window.innerHeight
 `
 // Mouse event simluation function
 function simulate(type, target, options) {
@@ -395,12 +397,12 @@ performDragOperation = (editor, drag, cb) ->
     dy: drag.drag.handle.y
   })
   simulate('mousemove', editor.dragCover, {
-    location: editor.mainScrollerStuffing
+    location: editor.mainCanvas
     dx: drag.drag.handle.x + editor.gutter.offsetWidth + 5,
     dy: drag.drag.handle.y + 5
   })
   simulate('mousemove', editor.dragCover, {
-    location: editor.mainScrollerStuffing
+    location: editor.mainCanvas
     dx: drag.drop.point.x + 5
     dy: drag.drop.point.y + 5
   })
@@ -466,6 +468,11 @@ asyncTest 'Controller: Random drag undo test', ->
   tick = (count) ->
     cb = ->
       if count is 0
+        stateStack.push editor.getValue()
+        text = stateStack.pop()
+        while stateStack[stateStack.length - 1] is text
+          text = stateStack.pop()
+
         while stateStack.length > 0
           text = stateStack.pop()
           while stateStack[stateStack.length - 1] is text


### PR DESCRIPTION
A new remember-socket PR to work with multiple documents. This will track the location of a socket through all (I think) operations except setValue.