### PR TITLE
Add line bounding box API

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -4016,8 +4016,10 @@ Editor::viewportDimensions = ->
 # =================
 Editor::getLineMetrics = (row) ->
   viewNode = @view.getViewNodeFor @tree
+  bounds = (new @view.draw.Rectangle()).copy(viewNode.bounds[row])
+  bounds.x += @mainCanvas.offsetLeft + @mainCanvas.offsetParent.offsetLeft
   return {
-    bounds: (new @view.draw.Rectangle()).copy(viewNode.bounds[row])
+    bounds: bounds
     distanceToBase: {
       above: viewNode.distanceToBase[row].above
       below: viewNode.distanceToBase[row].below

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -4014,8 +4014,15 @@ Editor::viewportDimensions = ->
 
 # LINE LOCATION API
 # =================
-Editor::getLineBoundingBox = (row) ->
-  return new @view.draw.Rectangle().copy(@view.getViewNodeFor(@tree).bounds[row])
+Editor::getLineMetrics = (row) ->
+  viewNode = @view.getViewNodeFor @tree
+  return {
+    bounds: (new @view.draw.Rectangle()).copy(viewNode.bounds[row])
+    distanceToBase: {
+      above: viewNode.distanceToBase[row].above
+      below: viewNode.distanceToBase[row].below
+    }
+  }
 
 # DEBUG CODE
 # ================================

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -4012,6 +4012,11 @@ Editor::viewportDimensions = ->
     height: @mainCanvas.height
   }
 
+# LINE LOCATION API
+# =================
+Editor::getLineBoundingBox = (row) ->
+  return new @view.draw.Rectangle().copy(@view.getViewNodeFor(@tree).bounds[row])
+
 # DEBUG CODE
 # ================================
 Editor::dumpNodeForDebug = (hitTestResult, line) ->

--- a/src/draw.coffee
+++ b/src/draw.coffee
@@ -87,6 +87,7 @@ exports.Draw = class Draw
 
       copy: (point) ->
         @x = point.x; @y = point.y
+        return @
 
       from: (point) -> new Point @x - point.x, @y - point.y
 
@@ -121,6 +122,7 @@ exports.Draw = class Draw
       copy: (rect) ->
         @x = rect.x; @y = rect.y
         @width = rect.width; @height = rect.height
+        return @
 
       clip: (ctx) ->
         ctx.rect @x, @y, @width, @height


### PR DESCRIPTION
`Editor.getLineBoundingBox(row)` where `row` is 0-indexed will return an instance of Droplet's `draw.Rectangle`, which has properties `x`, `y` ,`width`, `height` and methods `right()` and `bottom()`.