### PR TITLE
Add/Subtract buttons for blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ To have your parser actually put blocks in, you will need to do some things in t
   color: '#HEXCOLOR'
   precedence: Number
   classes: [] # Array of strings.
+  buttons: {
+    addButton: Boolean
+    subtractButton: Boolean
+  }
 })
 
 # Add a Socket
@@ -210,4 +214,22 @@ MyParser.drop = (block, context, preceding, succeeding) ->
     return helper.DISCOURAGE
   else
     return helper.FORBID
+
+# HandleButton is called whenever a button is clicked
+# You are allowed to modify this text provided
+# the new text forms a single block
+# which will replace the original block
+MyParser.handleButton = (text, command, block) ->
+  # "text" is the text of the block whose button was clicked
+  # "command" is the button which was clicked
+  # and is equal to 'add-button'
+  # or 'subtract-button' telling which block was clicked
+  # "block" contains information about the original block
+  switch command
+    when 'add-button'
+      return newText
+    when 'subtract-button'
+      return newText
+  # Return 'text' is you don't want to change anything
+  return text
 ```

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -907,6 +907,34 @@ hook 'mousedown', 1, (point, event, state) ->
     # the hit test opportunity for this event.
     state.consumedHitTest = true
 
+# If the user clicks inside a block
+# and the block contains a button
+# which is either add or subtract button
+# call the handleButton callback
+hook 'mousedown', 4, (point, event, state) ->
+  if state.consumedHitTest then return
+  if not @trackerPointIsInMain(point) then return
+
+  mainPoint = @trackerPointToMain point
+
+  #Buttons aren't clickable in a selection
+  if @lassoSelection? and @hitTest(mainPoint, @lassoSelection)? then return
+
+  hitTestResult = @hitTest mainPoint, @tree
+
+  if hitTestResult?
+    hitTestBlock = @view.getViewNodeFor hitTestResult
+    str = hitTestResult.stringifyInPlace()
+
+    if hitTestBlock.addButtonRect? and hitTestBlock.addButtonRect.contains mainPoint
+      line = @mode.handleButton str, 'add-button', hitTestResult.getReader()
+      @populateBlock hitTestResult, line
+      state.consumedHitTest = true
+    else if hitTestBlock.subtractButtonRect? and hitTestBlock.subtractButtonRect.contains mainPoint
+      line = @mode.handleButton str, 'subtract-button', hitTestResult.getReader()
+      @populateBlock hitTestResult, line
+      state.consumedHitTest = true
+
 # If the user lifts the mouse
 # before they have dragged five pixels,
 # abort stuff.
@@ -1884,6 +1912,31 @@ Editor::populateSocket = (socket, string) ->
       last = helper.connect last, new model.TextToken line
 
     @spliceIn (new model.List(first, last)), socket.start
+
+Editor::populateBlock = (block, string) ->
+  newBlock = @mode.parse(string, wrapAtRoot: false).start.next.container
+  if newBlock
+    # For Cursor Recovery
+    if @cursor.count < block.start.getLocation().count
+      # Before the block -> No special needs - Recoverable
+      @replace block, newBlock
+    else if @cursor.count < block.end.getLocation().count
+      # Inside the block -> Set to block Start - Not recoverable
+      # Pretty sure this can be handled better
+      # Not sure how to, though
+      @setCursor block, null, 'before'
+      @replace block, newBlock
+    else
+      # After the block -> Change count manually to recover - Recoverable
+      cursor = @cursor.clone()
+      oldBlockEnd = block.end.getLocation().count
+      # Need to set to a valid position before replacing block
+      @setCursor @tree
+      @replace block, newBlock
+      cursor.count += newBlock.end.getLocation().count - oldBlockEnd #Kind-of Hacky :P
+      @cursor = cursor
+    return true
+  return false
 
 # Convenience hit-testing function
 Editor::hitTestTextInput = (point, block) ->

--- a/src/draw.coffee
+++ b/src/draw.coffee
@@ -225,6 +225,10 @@ exports.Draw = class Draw
         @_points.unshift point
         @_cacheFlag = true
 
+      reverse: ->
+        @_points.reverse()
+        return this
+
       # ### Point containment ###
       # Accomplished with ray-casting
       contains: (point) ->

--- a/src/languages/html.coffee
+++ b/src/languages/html.coffee
@@ -84,11 +84,15 @@ exports.HTMLParser = class HTMLParser extends parser.Parser
 
   getClasses: (node) ->
     classes = [node.nodeName]
-    if node.nodeName in ['thead', 'tbody', 'tr', 'table', 'div']
-      classes = classes.concat 'add-button'
-      if node.childNodes.length isnt 0
-        classes = classes.concat 'subtract-button'
     return classes
+
+  getButtons: (node) ->
+    buttons = {}
+    if node.nodeName in ['thead', 'tbody', 'tr', 'table', 'div']
+      buttons.addButton = true
+      if node.childNodes.length isnt 0
+        buttons.subtractButton = true
+    return buttons
 
   getColor: (node) ->
     COLORS[node.nodeName] ? COLORS['Default']
@@ -261,6 +265,7 @@ exports.HTMLParser = class HTMLParser extends parser.Parser
       color: @getColor node
       classes: @getClasses node
       socketLevel: @getSocketLevel node
+      buttons: @getButtons node
 
   htmlSocket: (node, depth, precedence, bounds, classes) ->
     @addSocket
@@ -358,6 +363,57 @@ exports.HTMLParser = class HTMLParser extends parser.Parser
 
 HTMLParser.parens = (leading, trailing, node, context) ->
   return [leading, trailing]
+
+HTMLParser.handleButton = (text, button, oldblock) ->
+  classes = oldblock.classes
+  fragment = htmlParser.parseFragment text
+  @prototype.cleanTree fragment
+  block = fragment.childNodes[0]
+  prev = null
+  if block.nodeName is 'tr'
+    prev = 'td'
+  else if block.nodeName in ['table', 'thead', 'tbody']
+    prev = 'tr'
+  else if block.nodeName is 'div'
+    prev = 'div'
+  if prev
+    last = block.childNodes.length - 1
+    while last >= 0
+      if block.childNodes[last].nodeName is prev
+        break
+      last--
+    last++
+    if button is 'add-button'
+      indentPrefix = DEFAULT_INDENT_DEPTH
+      if block.childNodes?.length is 1 and block.childNodes[0].nodeName is '#text' and block.childNodes[0].value.trim().length is 0
+        block.childNodes[0].value = '\n'
+      else
+        lines = block.childNodes?[0]?.value?.split('\n')
+        if lines?.length > 1
+          indentPrefix = lines[lines.length - 1]
+      switch block.nodeName
+        when 'tr'
+          extra = htmlParser.parseFragment '\n' + indentPrefix + '<td></td>'
+        when 'table'
+          extra = htmlParser.parseFragment '\n' + indentPrefix + '<tr>\n' + indentPrefix + '\n' + indentPrefix + '</tr>'
+        when 'tbody'
+          extra = htmlParser.parseFragment '\n' + indentPrefix + '<tr>\n' + indentPrefix + '\n' + indentPrefix + '</tr>'
+        when 'thead'
+          extra = htmlParser.parseFragment '\n' + indentPrefix + '<tr>\n' + indentPrefix + '\n' + indentPrefix + '</tr>'
+        when 'div'
+          extra = htmlParser.parseFragment '\n' + indentPrefix + '<div>\n' + indentPrefix + '\n' + indentPrefix + '</div>'
+      block.childNodes = block.childNodes[...last].concat(extra.childNodes).concat block.childNodes[last...]
+    else if button is 'subtract-button'
+        mid = last - 2
+        while mid >= 0
+          if block.childNodes[mid].nodeName is prev
+            break
+          mid--
+        block.childNodes = (if mid >=0 then block.childNodes[..mid] else []).concat block.childNodes[last...]
+        if block.childNodes.length is 1 and block.childNodes[0].nodeName is '#text' and block.childNodes[0].value.trim().length is 0
+          block.childNodes[0].value = '\n  \n'
+
+  return htmlSerializer.serialize fragment
 
 HTMLParser.drop = (block, context, pred, next) ->
 

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -866,6 +866,8 @@ exports.Location = class Location
       other = other.getLocation()
     return other.count is @count and other.type is @type
 
+  clone: -> new Location @count, @type
+
 exports.TextLocation = class TextLocation
   constructor: (
     @row = 0,
@@ -943,7 +945,7 @@ exports.BlockEndToken = class BlockEndToken extends EndToken
   serialize: -> "</block>"
 
 exports.Block = class Block extends Container
-  constructor: (@precedence = 0, @color = 'blank', @socketLevel = helper.ANY_DROP, @classes = []) ->
+  constructor: (@precedence = 0, @color = 'blank', @socketLevel = helper.ANY_DROP, @classes = [], @buttons = {}) ->
     @start = new BlockStartToken this
     @end = new BlockEndToken this
 
@@ -961,7 +963,7 @@ exports.Block = class Block extends Container
     return null
 
   _cloneEmpty: ->
-    clone = new Block @precedence, @color, @socketLevel, @classes
+    clone = new Block @precedence, @color, @socketLevel, @classes, @buttons
     clone.currentlyParenWrapped = @currentlyParenWrapped
 
     return clone

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -117,7 +117,7 @@ exports.Parser = class Parser
       opts.color,
       opts.socketLevel,
       opts.classes,
-      false
+      opts.buttons
 
     block.parseContext = opts.parseContext # TODO unhack
 
@@ -477,6 +477,9 @@ Parser.drop = (block, context, pred, next) ->
   else
     return helper.ENCOURAGE
 
+Parser.handleButton = (text, command, oldblock) ->
+  return text
+
 Parser.empty = ''
 Parser.emptyIndent = ''
 
@@ -522,3 +525,5 @@ exports.wrapParser = (CustomParser) ->
       return [leading, trailing]
 
     drop: (block, context, pred, next) -> CustomParser.drop block, context, pred, next
+
+    handleButton: (text, command, oldblock) -> CustomParser.handleButton text, command, oldblock

--- a/src/view.coffee
+++ b/src/view.coffee
@@ -29,6 +29,9 @@ DROPDOWN_ARROW_HEIGHT = 8
 DROP_TRIANGLE_COLOR = '#555'
 
 DEFAULT_OPTIONS =
+  buttonWidth: 15
+  buttonHeight: 15
+  buttonPadding: 6
   showDropdowns: true
   padding: 5
   indentWidth: 10
@@ -1666,13 +1669,48 @@ exports.View = class View
 
       super
 
+      @extraWidth = 0
+      if @model.buttons.addButton
+        @extraWidth += @view.opts.buttonWidth + @view.opts.buttonPadding
+
+      if @model.buttons.subtractButton
+        @extraWidth += @view.opts.buttonWidth + @view.opts.buttonPadding
+
       # Blocks have a shape including a lego nubby "tab", and so
       # they need to be at least wide enough for tabWidth+tabOffset.
       for size, i in @minDimensions
         size.width = Math.max size.width,
             @view.opts.tabWidth + @view.opts.tabOffset
 
+      @minDimensions[@minDimensions.length - 1].width += @extraWidth
+
       return null
+
+    drawSelf: (ctx, style) ->
+      super
+
+      drawButton = (text, rect, ctx) =>
+        path = rect.toPath().reverse()
+        path.style.fillColor = @path.style.fillColor
+        if style.grayscale
+          path.style.fillColor = avgColor @path.style.fillColor, 0.5, '#888'
+        if style.selected
+          path.style.fillColor = avgColor @path.style.fillColor, 0.7, '#00F'
+        path.bevel = true;
+        path.draw ctx
+        textElement = new @view.draw.Text(new @view.draw.Point(0, 0), text)
+        dx = rect.width - textElement.bounds().width
+        dy = rect.height - @view.opts.textHeight
+        #console.log dx, dy
+        textElement.translate
+          x: rect.x + Math.ceil(dx / 2)
+          y: rect.y + Math.ceil(dy)
+        textElement.draw ctx
+
+      if @model.buttons.addButton
+        drawButton '+', @addButtonRect, ctx
+      if @model.buttons.subtractButton
+        drawButton '-', @subtractButtonRect, ctx
 
     shouldAddTab: ->
       if @model.parent?
@@ -1680,6 +1718,30 @@ exports.View = class View
         parent?.type isnt 'socket'
       else not ('mostly-value' in @model.classes or
           'value-only' in @model.classes)
+
+    computePath: ->
+      super
+      lastLine = @bounds.length - 1
+      lastRect = @bounds[lastLine]
+      start = lastRect.x + lastRect.width - @extraWidth
+      top = lastRect.y + lastRect.height/2 - @view.opts.buttonHeight/2
+      # Cases when last line is MULTILINE
+      if @multilineChildrenData[lastLine] is MULTILINE_END
+        multilineChild = @lineChildren[lastLine][0]
+        multilineBounds = @view.getViewNodeFor(multilineChild.child).bounds[lastLine - multilineChild.startLine]
+        # If it is a G-Shape
+        if @lineChildren[lastLine].length > 1
+          height = multilineBounds.bottom() - lastRect.y
+          top = lastRect.y + height/2 - @view.opts.buttonHeight/2
+        else
+          height = lastRect.bottom() - multilineBounds.bottom()
+          top = multilineBounds.bottom() + height/2 - @view.opts.buttonHeight/2
+
+      if @model.buttons.addButton
+        @addButtonRect = new @view.draw.Rectangle start, top, @view.opts.buttonWidth, @view.opts.buttonHeight
+        start += @view.opts.buttonWidth + @view.opts.buttonPadding
+      if @model.buttons.subtractButton
+        @subtractButtonRect = new @view.draw.Rectangle start, top, @view.opts.buttonWidth, @view.opts.buttonHeight
 
     computeOwnPath: ->
       super


### PR DESCRIPTION
Adds a new feature to droplet
Blocks can now have clickable buttons which are either '+' or '-'
Clicking a button allows changing text inside that block through a callback.
Can be used in cases where children of specific node are fixed. Simply add or remove the last child depending on which button is clicked.