### PR TITLE
Don't insert text blocks when Return is pressed if the Control or Command keys are held down

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -2807,7 +2807,7 @@ hook 'keydown', 0, (event, state) ->
   if @readOnly
     return
   if event.which is ENTER_KEY
-    if not @cursorAtSocket() and not event.shiftKey
+    if not @cursorAtSocket() and not event.shiftKey and not event.ctrlKey and not event.metaKey
       # Construct the block; flag the socket as handwritten
       newBlock = new model.Block(); newSocket = new model.Socket @mode.empty, Infinity
       newSocket.handwritten = true; newSocket.setParent newBlock


### PR DESCRIPTION
This fixes an issue in PencilCode where the shortcut to run the current program (Command-Return, or Control-Return on Linux/Windows) would also inadvertently add a new blank text block. Shift-Return was already excluded from inserting a new block.