### PR TITLE
Refactor default text selection range into modes for string assistance

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -2663,7 +2663,8 @@ Editor::setCursor = (destination, validate = (-> true), direction = 'after') ->
     @undoCapture()
     @hiddenInput.value = @getCursor().textContent()
     @hiddenInput.focus()
-    @setTextSelectionRange 0, @hiddenInput.value.length
+    {start, end} = @mode.getDefaultSelectionRange @hiddenInput.value
+    @setTextSelectionRange start, end
 
 Editor::determineCursorPosition = ->
   # Do enough of the redraw to get the bounds

--- a/src/languages/coffee.coffee
+++ b/src/languages/coffee.coffee
@@ -1111,4 +1111,10 @@ CoffeeScriptParser.parens = (leading, trailing, node, context) ->
 
   return
 
+CoffeeScriptParser.getDefaultSelectionRange = (string) ->
+  start = 0; end = string.length
+  if string[0] is string[string.length - 1] and string[0] in ['"', '\'', '/']
+    start += 1; end -= 1
+  return {start, end}
+
 module.exports = parser.wrapParser CoffeeScriptParser

--- a/src/languages/coffee.coffee
+++ b/src/languages/coffee.coffee
@@ -1113,9 +1113,9 @@ CoffeeScriptParser.parens = (leading, trailing, node, context) ->
 
 CoffeeScriptParser.getDefaultSelectionRange = (string) ->
   start = 0; end = string.length
-  if string[0] is string[string.length - 1] and string[0] in ['"', '\'', '/']
+  if string.length > 1 and string[0] is string[string.length - 1] and string[0] in ['"', '\'', '/']
     start += 1; end -= 1
-    if string[0..2] is string[-3..-1] and string[0..2] in ['"""', '\'\'\'', '///']
+    if string.length > 6 and string[0..2] is string[-3..-1] and string[0..2] in ['"""', '\'\'\'', '///']
       start += 2; end -= 2
   return {start, end}
 

--- a/src/languages/coffee.coffee
+++ b/src/languages/coffee.coffee
@@ -1115,6 +1115,8 @@ CoffeeScriptParser.getDefaultSelectionRange = (string) ->
   start = 0; end = string.length
   if string[0] is string[string.length - 1] and string[0] in ['"', '\'', '/']
     start += 1; end -= 1
+    if string[0..2] is string[-3..-1] and string[0..2] in ['"""', '\'\'\'', '///']
+      start += 2; end -= 2
   return {start, end}
 
 module.exports = parser.wrapParser CoffeeScriptParser

--- a/src/languages/coffee.coffee
+++ b/src/languages/coffee.coffee
@@ -1115,7 +1115,7 @@ CoffeeScriptParser.getDefaultSelectionRange = (string) ->
   start = 0; end = string.length
   if string.length > 1 and string[0] is string[string.length - 1] and string[0] in ['"', '\'', '/']
     start += 1; end -= 1
-    if string.length > 6 and string[0..2] is string[-3..-1] and string[0..2] in ['"""', '\'\'\'', '///']
+    if string.length > 5 and string[0..2] is string[-3..-1] and string[0..2] in ['"""', '\'\'\'', '///']
       start += 2; end -= 2
   return {start, end}
 

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -656,4 +656,10 @@ JavaScriptParser.emptyIndent = ""
 JavaScriptParser.startComment = '/*'
 JavaScriptParser.endComment = '*/'
 
+JavaScriptParser.getDefaultSelectionRange = (string) ->
+  start = 0; end = string.length
+  if string[0] is string[string.length - 1] and string[0] in ['"', '\'', '/']
+    start += 1; end -= 1
+  return {start, end}
+
 module.exports = parser.wrapParser JavaScriptParser

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -480,6 +480,8 @@ Parser.drop = (block, context, pred, next) ->
 Parser.empty = ''
 Parser.emptyIndent = ''
 
+getDefaultSelectionRange = (string) -> {start: 0, end: string.length}
+
 exports.wrapParser = (CustomParser) ->
   class CustomParserFactory extends ParserFactory
     constructor: (@opts = {}) ->
@@ -487,6 +489,7 @@ exports.wrapParser = (CustomParser) ->
       @emptyIndent = CustomParser.emptyIndent
       @startComment = CustomParser.startComment ? '/*'
       @endComment = CustomParser.endComment ? '*/'
+      @getDefaultSelectionRange = CustomParser.getDefaultSelectionRange ? getDefaultSelectionRange
 
     # TODO kind of hacky assignation of @empty,
     # maybe change the api?

--- a/test/src/uitest.coffee
+++ b/test/src/uitest.coffee
@@ -581,6 +581,56 @@ asyncTest 'Controller: remembered sockets', ->
     )
   ]
 
+asyncTest 'Controller: Quoted string selection', ->
+  document.getElementById('test-main').innerHTML = ''
+  window.editor = editor = new droplet.Editor(document.getElementById('test-main'), {
+    mode: 'coffeescript',
+    modeOptions:
+      functions:
+        fd: {command: true, value: false}
+        bk: {command: true, value: false}
+    palette: [
+      {
+        name: 'Blocks'
+        blocks: [
+          {block: 'a is b'}
+          {block: 'fd 10'}
+          {block: 'bk 10'}
+          {block: '''
+          for i in [0..10]
+            ``
+          '''}
+          {block: '''
+          if a is b
+            ``
+          '''}
+        ]
+      }
+    ]
+  })
+
+  editor.setEditorState(true)
+  editor.setValue('fd "hello"')
+
+  entity = editor.tree.getFromTextLocation({row: 0, col: 'fd '.length, type: 'socket'})
+  {x, y} = editor.view.getViewNodeFor(entity).bounds[0]
+
+  simulate('mousedown', editor.mainScrollerStuffing, {
+    dx: x + 5 + editor.gutter.offsetWidth
+    dy: y + 5
+  })
+  simulate('mouseup', editor.mainScrollerStuffing, {
+    dx: x + 5 + editor.gutter.offsetWidth
+    dy: y + 5
+  })
+
+  setTimeout (->
+    equal editor.hiddenInput.selectionStart, 1
+    equal editor.hiddenInput.selectionEnd, 6
+
+    start()
+  ), 0
+
 asyncTest 'Controller: Random drag undo test', ->
   document.getElementById('test-main').innerHTML = ''
   window.editor = editor = new droplet.Editor(document.getElementById('test-main'), {


### PR DESCRIPTION
Brings back and adds a test for the feature where by default Droplet does not select the quotes in a quoted string (or, now, regexes)