### PR TITLE
Fix string autoescape and add test

### DIFF
--- a/src/languages/coffee.coffee
+++ b/src/languages/coffee.coffee
@@ -180,13 +180,13 @@ exports.CoffeeScriptParser = class CoffeeScriptParser extends parser.Parser
 
   markRoot: ->
     # Preprocess comments
-    do @stripComments
-
     retries = Math.max(1, Math.min(5, Math.ceil(@lines.length / 2)))
     firstError = null
     # Get the CoffeeScript AST from the text
     loop
       try
+        do @stripComments
+
         tree = CoffeeScript.nodes(@text)
         annotateCsNodes tree
         nodes = tree.expressions
@@ -1032,11 +1032,11 @@ fixCoffeeScriptError = (lines, e) ->
 fixQuotedString = (lines) ->
   line = lines[0]
   quotechar = if /^"|"$/.test(line) then '"' else "'"
-  if line.getCharAt(0) is quotechar
+  if line.charAt(0) is quotechar
     line = line.substr(1)
-  if line.getCharAt(line.length - 1) is quotechar
-    line = line.substr(0, line.length -1)
-  return quoteAndCEscape fixQuotedLine line
+  if line.charAt(line.length - 1) is quotechar
+    line = line.substr(0, line.length - 1)
+  return lines[0] = quoteAndCEscape line
 
 looseCUnescape = (str) ->
   codes =

--- a/src/languages/coffee.coffee
+++ b/src/languages/coffee.coffee
@@ -1036,7 +1036,7 @@ fixQuotedString = (lines) ->
     line = line.substr(1)
   if line.charAt(line.length - 1) is quotechar
     line = line.substr(0, line.length - 1)
-  return lines[0] = quoteAndCEscape line
+  return lines[0] = quoteAndCEscape looseCUnescape(line), quotechar
 
 looseCUnescape = (str) ->
   codes =
@@ -1056,7 +1056,8 @@ quoteAndCEscape = (str, quotechar) ->
   result = JSON.stringify(str)
   if quotechar is "'"
     return quotechar +
-      result.substr(1, result.length -2).replace(/\\"/g, '"').
+      result.substr(1, result.length - 2).
+             replace(/((?:^|[^\\])(?:\\\\)*)\\"/g, '$1"').
       replace(/'/g, "\\'") + quotechar
   return result
 

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -427,7 +427,7 @@ exports.List = class List
     indent = []
 
     head = @start
-    until head is @end
+    while true
       if head instanceof IndentStartToken
         indent.push head.container.prefix
       else if head instanceof IndentEndToken
@@ -436,6 +436,9 @@ exports.List = class List
         str += '\n' + (head.specialIndent ? indent.join(''))
       else
         str += head.stringify()
+
+      if head is @end
+        break
       head = head.next
 
     return str

--- a/test/src/uitest.coffee
+++ b/test/src/uitest.coffee
@@ -210,7 +210,7 @@ asyncTest 'Controller: reparse fallback', ->
 
     ok(editor.cursorAtSocket(), 'Has text focus')
 
-    equal(editor.getCursor().stringify(), 'a, b')
+    equal(editor.getCursor().stringify(), 'a')
 
     start()
   ), 10)

--- a/test/src/uitest.coffee
+++ b/test/src/uitest.coffee
@@ -660,7 +660,7 @@ asyncTest 'Controller: Quoted string CoffeeScript autoescape', ->
   })
 
   editor.setEditorState(true)
-  editor.setValue('fd "hello"')
+  editor.setValue("fd 'hello'")
 
   entity = editor.tree.getFromTextLocation({row: 0, col: 'fd '.length, type: 'socket'})
   {x, y} = editor.view.getViewNodeFor(entity).bounds[0]
@@ -679,7 +679,7 @@ asyncTest 'Controller: Quoted string CoffeeScript autoescape', ->
       equal editor.hiddenInput.selectionStart, 1
       equal editor.hiddenInput.selectionEnd, 6
 
-      $('.droplet-hidden-input').sendkeys('hel"lo')
+      $('.droplet-hidden-input').sendkeys("h\\tel\\\\\"'lo")
     ), (->
       simulate('mousedown', editor.mainScrollerStuffing, {
         dx: 500
@@ -690,7 +690,7 @@ asyncTest 'Controller: Quoted string CoffeeScript autoescape', ->
         dy: 500
       })
     ), (->
-      equal editor.getValue(), 'fd "hel\\"lo"\n'
+      equal editor.getValue(), """fd 'h\\tel\\\\"\\'lo'\n"""
       start()
     )
   ]


### PR DESCRIPTION
Fixes a feature that has been broken for a while or may never have worked, where in CoffeeScript mode if students write a quote inside a string it will automatically escape it. Adds a test for this feature as well.