### PR TITLE
Add a socket when there are no params in a function call

### DIFF
--- a/src/languages/coffee.coffee
+++ b/src/languages/coffee.coffee
@@ -555,6 +555,8 @@ exports.CoffeeScriptParser = class CoffeeScriptParser extends parser.Parser
             @csSocketAndMark node.variable.base, depth + 1, 0, indentDepth
 
           if node.args.length is 0 and not node.do
+            # The only way we can have zero arguments in CoffeeScript
+            # is for the parenthesis to open immediately after the function name.
             variableBounds = @getBounds(node.variable)
             start = {
               line: variableBounds.end.line
@@ -588,7 +590,7 @@ exports.CoffeeScriptParser = class CoffeeScriptParser extends parser.Parser
               # Inline function definitions that appear as the last arg
               # of a function call will be melded into the parent block.
               @addCode arg, depth + 1, indentDepth
-            else if index is 0
+            else if index is 0 and node.args.length is 1
               @csSocketAndMark arg, depth + 1, precedence, indentDepth, null, known?.fn?.dropdown?[index], ''
             else
               @csSocketAndMark arg, depth + 1, precedence, indentDepth, null, known?.fn?.dropdown?[index]

--- a/src/languages/coffee.coffee
+++ b/src/languages/coffee.coffee
@@ -554,7 +554,7 @@ exports.CoffeeScriptParser = class CoffeeScriptParser extends parser.Parser
             # simple base object variable, let the variable be socketed.
             @csSocketAndMark node.variable.base, depth + 1, 0, indentDepth
 
-          if node.args.length is 0 and not node.do
+          if not known and node.args.length is 0 and not node.do
             # The only way we can have zero arguments in CoffeeScript
             # is for the parenthesis to open immediately after the function name.
             variableBounds = @getBounds(node.variable)

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -529,7 +529,9 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
         else if known.anyobj and node.callee.type is 'MemberExpression'
           @jsSocketAndMark indentDepth, node.callee.object, depth + 1, NEVER_PAREN
         for argument, i in node.arguments
-          @jsSocketAndMark indentDepth, argument, depth + 1, NEVER_PAREN, null, null, known?.fn?.dropdown?[i], (if i is 0 then '' else undefined)
+          @jsSocketAndMark indentDepth, argument, depth + 1, NEVER_PAREN, null, null, known?.fn?.dropdown?[i], (
+            if i is 0 and node.arguments.length is 1 then '' else undefined
+          )
         if node.arguments.length is 0
           position = {
             line: node.callee.loc.end.line

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -554,7 +554,7 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
             depth: depth + 1
             precedence: NEVER_PAREN
             dropdown: null
-            classes: ['no-drop']
+            classes: ['mostly-value']
             empty: ''
           }
       when 'MemberExpression'

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -529,7 +529,34 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
         else if known.anyobj and node.callee.type is 'MemberExpression'
           @jsSocketAndMark indentDepth, node.callee.object, depth + 1, NEVER_PAREN
         for argument, i in node.arguments
-          @jsSocketAndMark indentDepth, argument, depth + 1, NEVER_PAREN, null, null, known?.fn?.dropdown?[i]
+          @jsSocketAndMark indentDepth, argument, depth + 1, NEVER_PAREN, null, null, known?.fn?.dropdown?[i], (if i is 0 then '' else undefined)
+        if node.arguments.length is 0
+          position = {
+            line: node.callee.loc.end.line
+            column: node.callee.loc.end.column
+          }
+          string = @lines[position.line][position.column..].match(/^\s*\(/)[0]
+          position.column += string.length
+          endPosition = {
+            line: position.line
+            column: position.column
+          }
+          space = @lines[position.line][position.column..].match(/^(\s*)\)/)
+          if space?
+            endPosition.column += space[1].length
+          else
+            debugger
+          @addSocket {
+            bounds: {
+              start: position
+              end: endPosition
+            }
+            depth: depth + 1
+            precedence: NEVER_PAREN
+            dropdown: null
+            classes: ['no-drop']
+            empty: ''
+          }
       when 'MemberExpression'
         @jsBlock node, depth, bounds
         @jsSocketAndMark indentDepth, node.object, depth + 1

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -532,7 +532,7 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
           @jsSocketAndMark indentDepth, argument, depth + 1, NEVER_PAREN, null, null, known?.fn?.dropdown?[i], (
             if i is 0 and node.arguments.length is 1 then '' else undefined
           )
-        if node.arguments.length is 0
+        if not known and node.arguments.length is 0
           position = {
             line: node.callee.loc.end.line
             column: node.callee.loc.end.column
@@ -546,8 +546,6 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
           space = @lines[position.line][position.column..].match(/^(\s*)\)/)
           if space?
             endPosition.column += space[1].length
-          else
-            debugger
           @addSocket {
             bounds: {
               start: position

--- a/src/view.coffee
+++ b/src/view.coffee
@@ -40,6 +40,7 @@ DEFAULT_OPTIONS =
   dropAreaHeight: 20
   indentDropAreaMinWidth: 50
   minSocketWidth: 10
+  invisibleSocketWidth: 5
   textHeight: 15
   textPadding: 1
   emptyLineWidth: 50
@@ -1756,6 +1757,9 @@ exports.View = class View
 
     shouldAddTab: NO
 
+    isInvisibleSocket: ->
+      '' is @model.emptyString and @model.start?.next is @model.end
+
     # ## computeDimensions (SocketViewNode)
     # Sockets have a couple exceptions to normal dimension computation.
     #
@@ -1777,8 +1781,11 @@ exports.View = class View
           @minDistanceToBase[0].above + @minDistanceToBase[0].below
 
       for dimension in @minDimensions
-        dimension.width =
-            Math.max(dimension.width, @view.opts.minSocketWidth)
+        dimension.width = Math.max(dimension.width,
+          if @isInvisibleSocket()
+            @view.opts.invisibleSocketWidth
+          else
+            @view.opts.minSocketWidth)
 
         if @model.hasDropdown() and @view.opts.showDropdowns
           dimension.width += helper.DROPDOWN_ARROW_WIDTH
@@ -1838,10 +1845,12 @@ exports.View = class View
       else
         super
 
-      # Make ourselves white, with a
-      # gray border.
-      @path.style.fillColor = '#FFF'
-      @path.style.strokeColor = '#FFF'
+      if '' is @model.emptyString and @model.start?.next is @model.end
+        # Empty sockets with empty emptyString defaults are transparent
+        @path.style.fillColor = @path.style.strokeColor = 'rgba(0,0,0,0)'
+      else
+        # Make ourselves white, with a white border.
+        @path.style.fillColor = @path.style.strokeColor = '#FFF'
 
       return @path
 

--- a/test/src/cstest.coffee
+++ b/test/src/cstest.coffee
@@ -159,7 +159,11 @@ asyncTest 'Dotted methods', ->
       precedence="0"
       handwritten="false"
       classes="Literal"
-    >log</socket>.fd()</block></socket
+    >log</socket>.fd(<socket
+      precedence="0"
+      handwritten="false"
+      classes="mostly-value"
+    ></socket>)</block></socket
     ></block></socket
     ></block></socket
     ></block></socket></block
@@ -168,7 +172,11 @@ asyncTest 'Dotted methods', ->
       color="blue"
       socketLevel="0"
       classes="Call works-as-method-call mostly-block"
-    >fd()</block></document>'''
+    >fd(<socket
+      precedence="0"
+      handwritten="false"
+      classes="mostly-value"
+    ></socket>)</block></document>'''
   strictEqual(
       helper.xmlPrettyPrint(customSerialization),
       helper.xmlPrettyPrint(expectedSerialization),

--- a/test/src/cstest.coffee
+++ b/test/src/cstest.coffee
@@ -159,11 +159,7 @@ asyncTest 'Dotted methods', ->
       precedence="0"
       handwritten="false"
       classes="Literal"
-    >log</socket>.fd(<socket
-      precedence="0"
-      handwritten="false"
-      classes="mostly-value"
-    ></socket>)</block></socket
+    >log</socket>.fd()</block></socket
     ></block></socket
     ></block></socket
     ></block></socket></block
@@ -172,11 +168,7 @@ asyncTest 'Dotted methods', ->
       color="blue"
       socketLevel="0"
       classes="Call works-as-method-call mostly-block"
-    >fd(<socket
-      precedence="0"
-      handwritten="false"
-      classes="mostly-value"
-    ></socket>)</block></document>'''
+    >fd()</block></document>'''
   strictEqual(
       helper.xmlPrettyPrint(customSerialization),
       helper.xmlPrettyPrint(expectedSerialization),

--- a/test/src/jstest.coffee
+++ b/test/src/jstest.coffee
@@ -109,11 +109,7 @@ asyncTest 'JS dotted methods', ->
       color="red"
       socketLevel="0"
       classes="CallExpression mostly-block"
-    >pos(<socket
-      precedence="100"
-      handwritten="false"
-      classes="mostly-value"
-    ></socket>)</block></socket></block></socket
+    >pos()</block></socket></block></socket
     >)</block></socket
     >)</block></socket
     >)</block></socket

--- a/test/src/jstest.coffee
+++ b/test/src/jstest.coffee
@@ -109,7 +109,11 @@ asyncTest 'JS dotted methods', ->
       color="red"
       socketLevel="0"
       classes="CallExpression mostly-block"
-    >pos()</block></socket></block></socket
+    >pos(<socket
+      precedence="100"
+      handwritten="false"
+      classes="mostly-value"
+    ></socket>)</block></socket></block></socket
     >)</block></socket
     >)</block></socket
     >)</block></socket
@@ -305,7 +309,11 @@ asyncTest 'JS omits unary +/- for literals', ->
       '  precedence="100"' +
       '  handwritten="false"' +
       '  classes=""' +
-      '>a</socket>()</block></socket></block>' +
+      '>a</socket>(<socket
+        precedence="100"
+        handwritten="false"
+        classes="mostly-value"
+      ></socket>)</block></socket></block>' +
       '</socket>);</block></document>'
   strictEqual(
       helper.xmlPrettyPrint(customSerialization),
@@ -485,7 +493,11 @@ asyncTest 'JS beginner mode loops', ->
     '  precedence="100"' +
     '  handwritten="false"' +
     '  classes=""' +
-    '>go</socket>();</block></indent>\n}</block></document>'
+    '>go</socket>(<socket
+      precedence="100"
+      handwritten="false"
+      classes="mostly-value"
+    ></socket>);</block></indent>\n}</block></document>'
   strictEqual(
       helper.xmlPrettyPrint(customSerialization),
       helper.xmlPrettyPrint(expectedSerialization),


### PR DESCRIPTION
This affects JavaScript and CoffeeScript mode. This will not be done in JavaScript if there are intervening comments or line breaks between the function variable and parentheses.