### PR TITLE
Fix newline removal bug with +/- buttons

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -2210,7 +2210,14 @@ Editor::populateSocket = (socket, string) ->
 Editor::populateBlock = (block, string) ->
   newBlock = @mode.parse(string, wrapAtRoot: false).start.next.container
   if newBlock
+    # Find the first token before the block
+    # that will still be around after the
+    # block has been removed
     location = block.start.prev
+    while location?.type is 'newline' and not (
+          location.prev?.type is 'indentStart' and
+          location.prev.container.end is block.end.next)
+      location = location.prev
     @spliceOut block
     @spliceIn newBlock, location
     return true


### PR DESCRIPTION
Fixes a bug where, previously, a +/- button on a block that was not the first in its indent or document would cause Droplet to break.