### PR TITLE
Prevent reparsing of function parameters socket in JavaScript mode

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -2153,7 +2153,8 @@ Editor::reparse = (list, recovery, updates = [], originalTrigger = list) ->
     return if list.start.next is list.end
 
     originalText = list.textContent()
-    @reparse new model.List(list.start.next, list.end.prev), recovery, updates, originalTrigger
+    unless list.parseContext = 'NO_REPARSE'
+      @reparse new model.List(list.start.next, list.end.prev), recovery, updates, originalTrigger
 
     # Try reparsing the parent again after the reparse. If it fails,
     # repopulate with the original text and try again.

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -2152,15 +2152,18 @@ Editor::reparse = (list, recovery, updates = [], originalTrigger = list) ->
   if list.start.type is 'socketStart'
     return if list.start.next is list.end
 
-    originalText = list.textContent()
-    unless list.parseContext = 'NO_REPARSE'
+    # Sockets with 'NO_REPARSE' should bubble reparses up to the parent.
+    if list.parseContext = 'NO_REPARSE'
+      @reparse list.parent, recovery, updates, originalTrigger
+    else
+      originalText = list.textContent()
       @reparse new model.List(list.start.next, list.end.prev), recovery, updates, originalTrigger
 
-    # Try reparsing the parent again after the reparse. If it fails,
-    # repopulate with the original text and try again.
-    unless @reparse list.parent, recovery, updates, originalTrigger
-      @populateSocket list, originalText
-      @reparse list.parent, recovery, updates, originalTrigger
+      # Try reparsing the parent again after the reparse. If it fails,
+      # repopulate with the original text and try again.
+      unless @reparse list.parent, recovery, updates, originalTrigger
+        @populateSocket list, originalText
+        @reparse list.parent, recovery, updates, originalTrigger
     return
 
   parent = list.start.parent

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -370,6 +370,7 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
             dropdown: null
             classes: ['no-drop']
             empty: ''
+            parseContext: 'NO_REPARSE'
           }
         else if @opts.zeroParamFunctions
           nodeBoundsStart = @getBounds(node.id).end

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -1018,7 +1018,7 @@ exports.SocketEndToken = class SocketEndToken extends EndToken
     else ''
 
 exports.Socket = class Socket extends Container
-  constructor: (@emptyString, @precedence = 0, @handwritten = false, @classes = [], @dropdown = null) ->
+  constructor: (@emptyString, @precedence = 0, @handwritten = false, @classes = [], @dropdown = null, @parseContext) ->
     @start = new SocketStartToken this
     @end = new SocketEndToken this
 
@@ -1039,7 +1039,7 @@ exports.Socket = class Socket extends Container
 
   isDroppable: -> @start.next is @end or @start.next.type is 'text'
 
-  _cloneEmpty: -> new Socket @emptyString, @precedence, @handwritten, @classes, @dropdown
+  _cloneEmpty: -> new Socket @emptyString, @precedence, @handwritten, @classes, @dropdown, @parseContext
 
   _serialize_header: -> "<socket precedence=\"#{
       @precedence

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -115,7 +115,8 @@ exports.Parser = class Parser
     socket = new model.Socket opts.empty ? @empty, opts.precedence,
       false,
       opts.classes,
-      opts.dropdown
+      opts.dropdown,
+      opts.parseContext
 
     @addMarkup socket, opts.bounds, opts.depth
 


### PR DESCRIPTION
From @dabbler0: 
> I think the best way to fix this bug would be to set a flag on that parameter socket saying always to bubble up reparses to its parent (never reparse it by itself). In javascript.coffee, set the flag on that socket through the "parseContext" property of the socket (make it something like "NO_REPARSE"). Then, in Editor::reparse in controller.coffee, look for that value of "parseContext", and always bubble up when you see it.

Sockets didn't have a `parseContext` so I added it to the model and to `@addSocket`.  When `parseContext == 'NO_REPARSE'` the reparse of the socket contents is skipped, and the parent is reparsed as a whole.

`'NO_REPARSE'` context is set for the JavaScript FunctionDeclaration parameters socket.