### PR TITLE
Restore update locations when a socket reparse fails

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -2153,12 +2153,17 @@ Editor::reparse = (list, recovery, updates = [], originalTrigger = list) ->
     return if list.start.next is list.end
 
     originalText = list.textContent()
+    originalUpdates = updates.map (location) ->
+      count: location.count, type: location.type
     @reparse new model.List(list.start.next, list.end.prev), recovery, updates, originalTrigger
 
     # Try reparsing the parent again after the reparse. If it fails,
     # repopulate with the original text and try again.
     unless @reparse list.parent, recovery, updates, originalTrigger
       @populateSocket list, originalText
+      originalUpdates.forEach (location, i) ->
+        updates[i].count = location.count
+        updates[i].type = location.type
       @reparse list.parent, recovery, updates, originalTrigger
     return
 


### PR DESCRIPTION
Prior to this change, socket reparse would modify the `updates` array of locations, but not restore the original values if the parent fails to parse with the new socket value. This would cause `Container#getFromLocation` to throw after falling off the end of the linked list.

The fix is to save the update locations before attempting to parse the socket as a new block, and restore them if the parent reparse fails.

This is a better fix for the JavaScript function sockets bug than https://github.com/droplet-editor/droplet/pull/130, which only treats the symptom but not the root cause.