### PR TITLE
Fix cmd+x having `pressedVKey = true`

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -4325,16 +4325,11 @@ hook 'populate', 1, ->
   pressedXKey = false
 
   @copyPasteInput.addEventListener 'keydown', (event) ->
+    pressedVKey = pressedXKey = false
     if event.keyCode is 86
       pressedVKey = true
     else if event.keyCode is 88
       pressedXKey = true
-
-  @copyPasteInput.addEventListener 'keyup', (event) ->
-    if event.keyCode is 86
-      pressedVKey = false
-    else if event.keyCode is 88
-      pressedXKey = false
 
   @copyPasteInput.addEventListener 'input', =>
     if @readOnly


### PR DESCRIPTION
Cut and paste could get the editor into a bad state because `pressedVKey` wasn't always being cleared. Pressing `cmd+v` then `cmd+x` would hit the paste code path and throw.