### PR TITLE
Enable custom builds with only one language

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -8,7 +8,7 @@ path = require 'path'
 fs = require 'fs'
 
 if process.env.LANGUAGE
-  ignoredLanguages = ['./src/languages/!(' + process.env.LANGUAGE + ').coffee']
+  ignoredLanguages = ["./src/languages/!(#{process.env.LANGUAGE}).coffee"]
 
 serveNoDottedFiles = (connect, options, middlewares) ->
   # Avoid leaking .git/.svn or other dotted files from test servers.

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -7,6 +7,9 @@ livereload = require 'tiny-lr'
 path = require 'path'
 fs = require 'fs'
 
+if process.env.LANGUAGE
+  ignoredLanguages = ['./src/languages/!(' + process.env.LANGUAGE + ').coffee']
+
 serveNoDottedFiles = (connect, options, middlewares) ->
   # Avoid leaking .git/.svn or other dotted files from test servers.
   middlewares.unshift (req, res, next) ->
@@ -75,6 +78,7 @@ module.exports = (grunt) ->
         files:
           'dist/droplet-full.js': ['./src/main.coffee']
         options:
+          ignore: ignoredLanguages
           transform: ['coffeeify']
           browserifyOptions:
             standalone: 'droplet'


### PR DESCRIPTION
With `grunt build uglify` droplet-full.min.js is ~1.57 mb.
With `LANGUAGE=javascript grunt build uglify` droplet-full.min.js is ~0.31 mb (1/5 the size).

This is important during Hour of Code where every byte across the wire counts!