### PR TITLE
Unify `@opts.zeroParamFunctions` behavior

### DIFF
--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -371,7 +371,7 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
             classes: ['no-drop']
             empty: ''
           }
-        else if @opts.zeroParamFunctions
+        else unless @opts.lockZeroParamFunctions
           nodeBoundsStart = @getBounds(node.id).end
           match = @lines[nodeBoundsStart.line][nodeBoundsStart.column..].match(/^(\s*\()(\s*)\)/)
           if match?
@@ -409,7 +409,7 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
             classes: ['no-drop']
             empty: ''
           }
-        else if @opts.zeroParamFunctions
+        else unless @opts.lockZeroParamFunctions
           if node.id?
             nodeBoundsStart = @getBounds(node.id).end
             match = @lines[nodeBoundsStart.line][nodeBoundsStart.column..].match(/^(\s*\()(\s*)\)/)
@@ -528,7 +528,7 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
           @jsSocketAndMark indentDepth, argument, depth + 1, NEVER_PAREN, null, null, known?.fn?.dropdown?[i], (
             if i is 0 and node.arguments.length is 1 then '' else undefined
           )
-        if not known and node.arguments.length is 0
+        if not known and node.arguments.length is 0 and not @opts.lockZeroParamFunctions
           position = {
             line: node.callee.loc.end.line
             column: node.callee.loc.end.column


### PR DESCRIPTION
Commit https://github.com/droplet-editor/droplet/commit/62b40fb727cd5a938fb49342b19c7136660decf7 added a click-target for user-defined functions with no parameters, so new params could be added in block mode.  Commit https://github.com/droplet-editor/droplet/commit/bb283afba434d38aee0201f420b72cfc939fa6d6 made that option configurable, but seems to have changed the default behavior to `false`.

This change re-enables adding params to user-definied functions with no params. It also updates function calls to also respect the `@opts.lockZeroParamFunctions` flag.

The default value of the modified flag is `false`, which doesn't lock zero-parameter functions (new parameters may be added by clicking inside the parentheses).