### PR TITLE
Clicking the palette scrollbar shouldn't trigger a mousedown event

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -245,8 +245,8 @@ exports.Editor = class Editor
     for eventName, elements of {
         keydown: [@dropletElement, @paletteElement]
         keyup: [@dropletElement, @paletteElement]
-        mousedown: [@dropletElement, @paletteElement, @dragCover]
-        dblclick: [@dropletElement, @paletteElement, @dragCover]
+        mousedown: [@dropletElement, @paletteHeader, @paletteScrollerStuffing, @dragCover]
+        dblclick: [@dropletElement, @paletteHeader, @paletteScrollerStuffing, @dragCover]
         mouseup: [window]
         mousemove: [window] } then do (eventName, elements) =>
       for element in elements


### PR DESCRIPTION
Fixes #104.  Bind events separately for `.droplet-palette-header` and `.droplet-palette-scroller-stuffing` so clicking the palette scrollbar doesn't trigger the callback.