### PR TITLE
Revert "Clicking the palette scrollbar shouldn't trigger a mousedown event"

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -245,8 +245,8 @@ exports.Editor = class Editor
     for eventName, elements of {
         keydown: [@dropletElement, @paletteElement]
         keyup: [@dropletElement, @paletteElement]
-        mousedown: [@dropletElement, @paletteHeader, @paletteScrollerStuffing, @dragCover]
-        dblclick: [@dropletElement, @paletteHeader, @paletteScrollerStuffing, @dragCover]
+        mousedown: [@dropletElement, @paletteElement, @dragCover]
+        dblclick: [@dropletElement, @paletteElement, @dragCover]
         mouseup: [window]
         mousemove: [window] } then do (eventName, elements) =>
       for element in elements


### PR DESCRIPTION
Reverts droplet-editor/droplet#135 due to a regression in IE10.  Blocks couldn't be dragged out from the toolbox because the `.palette-scroller-stuffing` didn't receive mouse events.