### PR TITLE
Fix off-by-one bug in the if/else add-button

### DIFF
--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -772,7 +772,7 @@ JavaScriptParser.handleButton = (text, button, oldBlock) ->
 
     if elseLocation?
       lines = text.split('\n')
-      elseLocation = lines[...elseLocation.line].join('\n').length + elseLocation.column
+      elseLocation = lines[...elseLocation.line].join('\n').length + elseLocation.column + 1
       return text[...elseLocation].trimRight() + ' if (__) ' + text[elseLocation..].trimLeft() + ''' else {
         __
       }'''


### PR DESCRIPTION
Incorrect JS was generated when pressing the '+' button on an else statement with no space before the bracket.

Before: `else{` -> `els if (__) e{`
After: `else{` -> `else if {`

The incorrect JS would fail to parse, throwing an error in acorn.js.  To the end-user it would appear as if the '+' button had no effect.

This bug was hidden for else statements with a space because `elseLocation` could be moved back one character (across the space) and still not impact the 'else' token.  The bug is only triggered when the space is missing.  Both tokens are trimmed after splitting so there is no change in the generated output.