### PR TITLE
Restrict version of patch5 as newer versions break tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "acorn": "^1.2.2",
     "sax": "^1.1.1",
     "antlr4": "latest",
-    "parse5": "latest"
+    "parse5": "1.5.1"
   }
 }


### PR DESCRIPTION
We started seeing the following failures on newer versions of patch5
```
Testing test/htmltest.html F
>> global failure
>> Message: TypeError: 'undefined' is not a constructor (evaluating 'new parse5.Parser(null, {
>>   decodeHtmlEntities: false,
>>   locationInfo: true
>> })')
>> Actual: null
>> Expected: undefined
>> file:///Users/brent/git/droplet/test/js/htmltest.js:16105

Testing test/jstest.html .......OK
Testing test/test.html F
>> global failure
>> Message: TypeError: 'undefined' is not a constructor (evaluating 'new parse5.Parser(null, {
>>   decodeHtmlEntities: false,
>>   locationInfo: true
>> })')
>> Actual: null
>> Expected: undefined
>> file:///Users/brent/git/droplet/test/js/tests.js:150972

Testing test/uitest.html F
>> global failure
>> Message: TypeError: 'undefined' is not a constructor (evaluating 'new parse5.Parser(null, {
>>   decodeHtmlEntities: false,
>>   locationInfo: true
>> })')
>> Actual: null
>> Expected: undefined
>> file:///Users/brent/git/droplet/test/js/uitest.js:69245
```

This restricts us to the old, non-failing version.