### PR TITLE
Ensure simple for loops don't have a block in node.test.right socket

### DIFF
--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -736,6 +736,7 @@ isStandardForLoop = (node) ->
       node.test.operator is '<' and
       node.test.left.type is 'Identifier' and
       node.test.left.name is variableName and
+      node.test.right.type in ['Literal', 'Identifier'] and
       node.update.type is 'UpdateExpression' and
       node.update.operator is '++' and
       node.update.argument.type is 'Identifier' and


### PR DESCRIPTION
This bug fix is for when the 'beginner' config option is set.  Without this change the following JS throws a parser error when switching from text to block mode:
```javascript
var items = [4, 5, 6];
for (var i = 0; i < items.length; i++) {
  //
}
```
This is because the beginner for loop doesn't expect a nested block inside the test condition.

I've updated `isStandardForLoop` to also check that the right-side test is a Literal or Identifier.  If it's not, Droplet falls back to parsing the node as a non-beginner for loop.

---

Beginner for loop:
![beginner-for-loop](https://cloud.githubusercontent.com/assets/413693/12598736/f800198e-c440-11e5-9e21-67b2b7589a24.png)

Non-beginner for loop:
![non-beginner-for-loop](https://cloud.githubusercontent.com/assets/413693/12598739/fd7eb1fe-c440-11e5-92f6-0479df4514a7.png)