### PR TITLE
Calling `getFromTextLocation` at location 0 should return a block

### DIFF
--- a/src/model.coffee
+++ b/src/model.coffee
@@ -699,6 +699,9 @@ exports.Container = class Container extends List
     head = @start
     best = head
 
+    if head instanceof DocumentStartToken
+      head = head.next
+
     row = 0
 
     until not head? or row is location.row


### PR DESCRIPTION
Before this change it returned the `DocumentStartToken`.  This ensures that calling `Editor::markBlock` with location `{row: 0, col: 0}` does mark the first block.