### PR TITLE
Breaking API change with latest parse5 

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "acorn": "^1.2.2",
     "sax": "^1.1.1",
     "antlr4": "latest",
-    "parse5": "latest"
+    "parse5": "1.5.1"
   }
 }


### PR DESCRIPTION
breaking changes were introduced with the 2.0.0 release

quick fix is to use the 1.5.1 version (latest version prior to breaking changes)
https://github.com/inikulin/parse5/wiki/Documentation#200

you may be interested in updating usage of the parse5 library, but this fix will work for now.