### PR TITLE
add NEVER_PAREN to both sides of AssignmentExpression

### DIFF
--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -439,8 +439,8 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
             }
       when 'AssignmentExpression'
         @jsBlock node, depth, bounds
-        @jsSocketAndMark indentDepth, node.left, depth + 1, null
-        @jsSocketAndMark indentDepth, node.right, depth + 1, null
+        @jsSocketAndMark indentDepth, node.left, depth + 1, NEVER_PAREN
+        @jsSocketAndMark indentDepth, node.right, depth + 1, NEVER_PAREN
       when 'ReturnStatement'
         @jsBlock node, depth, bounds
         if node.argument?

--- a/test/src/jstest.coffee
+++ b/test/src/jstest.coffee
@@ -168,12 +168,12 @@ asyncTest 'JS Custom Colors', ->
       socketLevel="0"
       classes="mostly-block AssignmentExpression"
     >(<socket
-      precedence="0"
+      precedence="100"
       handwritten="false"
       classes=""
     >a</socket
     > += <socket
-      precedence="0"
+      precedence="100"
       handwritten="false"
       classes=""
     ><block


### PR DESCRIPTION
Parentheses were being added when editing sockets on either side of an `AssignmentExpression`. However, the right side of the `VariableDeclarator` used `NEVER_PAREN`. So `x = __;` behaved differently from `var x = __;`
Changed `AssignmentExpression` to use `NEVER_PAREN` to match.