### PR TITLE
Limit scope of redraws for highlights and cursors

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -2605,7 +2605,7 @@ Editor::resizeLassoCanvas = ->
 
 Editor::clearLassoSelection = ->
   @lassoSelection = null
-  @redrawMain()
+  @redrawHighlights()
 
 # On mousedown, if nobody has taken
 # a hit test yet, start a lasso select.
@@ -2742,7 +2742,7 @@ hook 'mouseup', 0, (point, event, state) ->
     @lassoSelectAnchor = null
     @clearLassoSelectCanvas()
 
-    @redrawMain()
+    @redrawHighlights()
   @lassoSelectionDocument = null
 
 # On mousedown, we might want to

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -591,7 +591,6 @@ Editor::redrawHighlights = ->
     ), {grayscale: true}
     @maskFloatingPaths(@draggingBlock.getDocument())
 
-  @redrawCursors()
   @redrawLassoHighlight()
 
 Editor::clearCursorCanvas = ->

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -1714,7 +1714,6 @@ hook 'mouseup', 0, (point, event, state) ->
 
     @clearDrag()
     @redrawMain()
-    @redrawHighlights()
 
 Editor::performFloatingOperation = (op, direction) ->
   if (op.type is 'create') is (direction is 'forward')
@@ -2815,7 +2814,6 @@ Editor::setCursor = (destination, validate = (-> true), direction = 'after') ->
 
   @redrawMain()
   @highlightFlashShow()
-  @redrawHighlights()
 
   # If we are now at a text input, populate the hidden input
   if @cursorAtSocket()


### PR DESCRIPTION
There were a few places where Droplet redraws more than it needs to.  These changes are part of the focus-socket-on-mouseup changes.  Moving them to a separate PR to merge them early.