### PR TITLE
Lock grunt-contrib-connect to the last version that supports npm 0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "grunt-cli": "latest",
     "grunt-contrib-coffee": "latest",
     "grunt-contrib-concat": "latest",
-    "grunt-contrib-connect": "latest",
+    "grunt-contrib-connect": "1.0.0",
     "grunt-contrib-cssmin": "latest",
     "grunt-contrib-qunit": "<=0.5.2",
     "grunt-contrib-uglify": "latest",


### PR DESCRIPTION
Version 1.0.1 has a breaking change for npm 0.10, but 1.0.0 works.