### PR TITLE
Redraw when an add- or subtract-button click is handled

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -1197,10 +1197,12 @@ hook 'mousedown', 4, (point, event, state) ->
     if hitTestBlock.addButtonRect? and hitTestBlock.addButtonRect.contains mainPoint
       line = @mode.handleButton str, 'add-button', hitTestResult.getReader()
       @populateBlock hitTestResult, line
+      @redrawMain()
       state.consumedHitTest = true
     else if hitTestBlock.subtractButtonRect? and hitTestBlock.subtractButtonRect.contains mainPoint
       line = @mode.handleButton str, 'subtract-button', hitTestResult.getReader()
       @populateBlock hitTestResult, line
+      @redrawMain()
       state.consumedHitTest = true
 
 # If the user lifts the mouse


### PR DESCRIPTION
Prior to https://github.com/droplet-editor/droplet/pull/150 the redraw was triggered indirectly via `mousedown -> clearLassoSelection() -> redrawHighlights() -> redrawMain()`.

This fixes the bug where pressing the '+' button on an `if` block appears to have no effect until something else happens to trigger a `redrawMain()`.