### PR TITLE
expose changePaletteGroup method, allow groups to have ids

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -1834,8 +1834,10 @@ Editor::setPalette = (paletteGroups) ->
         paletteHeaderRow.style.height = 0
 
     # Create the element itself
-    paletteGroupHeader = document.createElement 'div'
+    paletteGroupHeader = paletteGroup.header = document.createElement 'div'
     paletteGroupHeader.className = 'droplet-palette-group-header'
+    if paletteGroup.id
+      paletteGroupHeader.id = 'droplet-palette-group-header-' + paletteGroup.id
     paletteGroupHeader.innerText = paletteGroupHeader.textContent = paletteGroupHeader.textContent = paletteGroup.name # innerText and textContent for FF compatability
     if paletteGroup.color
       paletteGroupHeader.className += ' ' + paletteGroup.color
@@ -1854,32 +1856,12 @@ Editor::setPalette = (paletteGroups) ->
         title: data.title
         id: data.id
 
-    paletteGroupBlocks = newPaletteBlocks
+    paletteGroup.parsedBlocks = newPaletteBlocks
 
     # When we click this element,
     # we should switch to it in the palette.
     updatePalette = =>
-      # Record that we are the selected group now
-      @currentPaletteGroup = paletteGroup.name
-      @currentPaletteBlocks = paletteGroupBlocks
-      @currentPaletteMetadata = paletteGroupBlocks
-
-      # Unapply the "selected" style to the current palette group header
-      @currentPaletteGroupHeader?.className =
-          @currentPaletteGroupHeader.className.replace(
-              /\s[-\w]*-selected\b/, '')
-
-      # Now we are the current palette group header
-      @currentPaletteGroupHeader = paletteGroupHeader
-      @currentPaletteIndex = i
-
-      # Apply the "selected" style to us
-      @currentPaletteGroupHeader.className +=
-          ' droplet-palette-group-header-selected'
-
-      # Redraw the palette.
-      @rebuildPalette()
-      @fireEvent 'selectpalette', [paletteGroup.name]
+      @changePaletteGroup paletteGroup
 
     clickHandler = =>
       do updatePalette
@@ -1893,6 +1875,37 @@ Editor::setPalette = (paletteGroups) ->
 
   @resizePalette()
   @resizePaletteHighlight()
+
+Editor::changePaletteGroup = (group) ->
+  for curGroup, i in @paletteGroups
+    if group is curGroup or group is curGroup.id or group is curGroup.name
+      paletteGroup = curGroup
+      break
+
+  if not paletteGroup
+    return
+
+  # Record that we are the selected group now
+  @currentPaletteGroup = paletteGroup.name
+  @currentPaletteBlocks = paletteGroup.parsedBlocks
+  @currentPaletteMetadata = paletteGroup.parsedBlocks
+
+  # Unapply the "selected" style to the current palette group header
+  @currentPaletteGroupHeader?.className =
+      @currentPaletteGroupHeader.className.replace(
+          /\s[-\w]*-selected\b/, '')
+
+  # Now we are the current palette group header
+  @currentPaletteGroupHeader = paletteGroup.header
+  @currentPaletteIndex = i
+
+  # Apply the "selected" style to us
+  @currentPaletteGroupHeader.className +=
+      ' droplet-palette-group-header-selected'
+
+  # Redraw the palette.
+  @rebuildPalette()
+  @fireEvent 'selectpalette', [paletteGroup.name]
 
 # The next thing we need to do with the palette
 # is let people pick things up from it.

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -1876,6 +1876,9 @@ Editor::setPalette = (paletteGroups) ->
   @resizePalette()
   @resizePaletteHighlight()
 
+# Change which palette group is selected.
+# group argument can be object, id (string), or name (string)
+#
 Editor::changePaletteGroup = (group) ->
   for curGroup, i in @paletteGroups
     if group is curGroup or group is curGroup.id or group is curGroup.name


### PR DESCRIPTION
* We want to allow certain levels in our curriculum to start up droplet with the palette group as something other than the default group (which is currently always the first one).
* Allow the supplied `@paletteGroups` object to optionally specify an `id` for each group. When present, it will be used to generate a DOM id for the group header (e.g. if `math` is the id, the header DOM id will be `droplet-palette-group-header-math`). This is useful for assigning tooltips to the header elements.
* Exposed a new `changePaletteGroup(group)` method and changed the existing code to use that method. The `group` parameter will be used to match from the `@paletteGroups` array - it can match the group object itself, the `name`, or the `id` of the group.
* The `@paletteGroups` object (supplied at editor creation) is now extended to retain the `header` element and the `parsedBlocks` array since they are no longer available through a closure.