### PR TITLE
Single-line comment changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "grunt-cli": "latest",
     "grunt-contrib-coffee": "latest",
     "grunt-contrib-concat": "latest",
-    "grunt-contrib-connect": "1.0.0",
+    "grunt-contrib-connect": "latest",
     "grunt-contrib-cssmin": "latest",
     "grunt-contrib-qunit": "<=0.5.2",
     "grunt-contrib-uglify": "latest",
@@ -56,6 +56,6 @@
     "acorn": "^1.2.2",
     "sax": "^1.1.1",
     "antlr4": "latest",
-    "parse5": "1.5.1"
+    "parse5": "latest"
   }
 }

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -2864,9 +2864,11 @@ Editor::setCursor = (destination, validate = (-> true), direction = 'after') ->
 
   # If the cursor was at a text input, reparse the old one
   if @cursorAtSocket() and not @cursor.is(destination)
-    @reparse @getCursor(), null, (if destination.document is @cursor.document then [destination.location] else [])
-    @hiddenInput.blur()
-    @dropletElement.focus()
+    socket = @getCursor()
+    if '__comment__' not in socket.classes
+      @reparse socket, null, (if destination.document is @cursor.document then [destination.location] else [])
+      @hiddenInput.blur()
+      @dropletElement.focus()
 
   @cursor = destination
 
@@ -3074,7 +3076,8 @@ hook 'keydown', 0, (event, state) ->
         newBlock.classes = ['__comment__', 'block-only']
         newBlock.socketLevel = helper.BLOCK_ONLY
         newTextMarker = new model.TextToken @mode.startSingleLineComment
-        newSocket = new model.Socket @mode.empty, 0, true
+        newTextMarker.setParent newBlock
+        newSocket = new model.Socket '', 0, true
         newSocket.classes = ['__comment__']
         newSocket.setParent newBlock
 

--- a/src/languages/coffee.coffee
+++ b/src/languages/coffee.coffee
@@ -217,6 +217,9 @@ exports.CoffeeScriptParser = class CoffeeScriptParser extends parser.Parser
   isComment: (str) ->
     str.match(/^\s*#.*$/)?
 
+  indentAndCommentMarker: (str) ->
+    str.match(/^\s*#/)?[0]
+
   stripComments: ->
     # Preprocess comment lines:
     try
@@ -1131,6 +1134,7 @@ CoffeeScriptParser.empty = "``"
 CoffeeScriptParser.emptyIndent = "``"
 CoffeeScriptParser.startComment = '###'
 CoffeeScriptParser.endComment = '###'
+CoffeeScriptParser.startSingleLineComment = '# '
 
 CoffeeScriptParser.drop = (block, context, pred) ->
   if context.type is 'socket'

--- a/src/languages/html.coffee
+++ b/src/languages/html.coffee
@@ -540,6 +540,9 @@ exports.HTMLParser = class HTMLParser extends parser.Parser
   isComment: (text) ->
     text.match(/<!--.*-->/)
 
+  indentAndCommentMarker: (text) ->
+    return ['']
+
 HTMLParser.parens = (leading, trailing, node, context) ->
   return [leading, trailing]
 

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -345,6 +345,9 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
   isComment: (text) ->
     text.match(/^\s*\/\/.*$/)
 
+  indentAndCommentMarker: (text) ->
+    text.match(/^\s*\/\//)[0]
+
   mark: (indentDepth, node, depth, bounds) ->
     switch node.type
       when 'Program'
@@ -754,6 +757,7 @@ JavaScriptParser.empty = "__"
 JavaScriptParser.emptyIndent = ""
 JavaScriptParser.startComment = '/*'
 JavaScriptParser.endComment = '*/'
+JavaScriptParser.startSingleLineComment = '//'
 
 JavaScriptParser.handleButton = (text, button, oldBlock) ->
   if button is 'add-button' and 'IfStatement' in oldBlock.classes

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -413,7 +413,6 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
           else
             newLastArgPosition = node.expression.arguments[argCount - 2].end
           return text[...newLastArgPosition].trimRight() + text[lastArgPosition..].trimLeft()
->>>>>>> code-dot-org
 
   mark: (indentDepth, node, depth, bounds) ->
     switch node.type

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -205,7 +205,8 @@ exports.Parser = class Parser
   # text inside
   constructHandwrittenBlock: (text) ->
     block = new model.Block 0, 'blank', helper.ANY_DROP
-    socket = new model.Socket @empty, 0, true
+    socket = new model.Socket '', 0, true
+    socket.setParent block
 
     if @isComment text
       posAfterIndentAndCommentMarker = @indentAndCommentMarker(text).length
@@ -219,9 +220,11 @@ exports.Parser = class Parser
       block.classes = ['__handwritten__', 'block-only']
 
     textToken = new model.TextToken text
+    textToken.setParent block
 
     if textPrefix
       textPrefixToken = new model.TextToken textPrefix
+      textPrefixToken.setParent block
       helper.connect block.start, textPrefixToken
       helper.connect textPrefixToken, socket.start
     else

--- a/src/treewalk.coffee
+++ b/src/treewalk.coffee
@@ -16,6 +16,9 @@ exports.createTreewalkParser = (parse, config, root) ->
     isComment: (text) ->
       text.match(/^\s*\/\/.*$/)
 
+    indentAndCommentMarker: (text) ->
+      text.match(/^\s*\/\//)[0]
+
     markRoot: (context = root) ->
       parseTree = parse(context, @text)
 


### PR DESCRIPTION
* Change `constructHandwrittenBlock` in the `isComment` case to call a new `indentAndCommentMarker` function, to handle single-line comments such that the comment marker is outside of the socket (and therefore, can't be deleted)
* Changed how the `ENTER_KEY` is handled when inside a socket in a comment: Previously, nothing happened. Now, a new single-line comment is created on the next line with the focus in the new socket so that typing can continue.
* Fixed some issues with how handwritten blocks are constructed by properly parenting the `TextToken` and `Socket` that belong to the new block.
* Fixed an issue where `@setCursor` would cause comments to be reparsed - and blank comments would fail to parse
_NOTE: multi-line comments still have issues and this PR does not address those issues_
_NOTE: single-line comment support was added for JavaScript and CoffeeScript only_