### PR TITLE
allow objectDropdown in known.anyobj, allow changing socket in dropdownOnly mode

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -2524,6 +2524,9 @@ Editor::showDropdown = (socket = @getCursor(), inPalette = false) ->
       if inPalette
         @populateSocket socket, text
         @redrawPalette()
+      else if not socket.editable()
+        @populateSocket socket, text
+        @redrawMain()
       else
         if not @cursorAtSocket()
           return

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -596,8 +596,8 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
         argCount = node.arguments.length
         if known?.fn
           showButtons = known.fn.minArgs? or known.fn.maxArgs?
-          minArgs = known.fn.minArgs or 0
-          maxArgs = if known.fn.maxArgs? then known.fn.maxArgs else Infinity
+          minArgs = known.fn.minArgs ? 0
+          maxArgs = known.fn.maxArgs ? Infinity
         else
           showButtons = @opts.paramButtonsForUnknownFunctions and
               (argCount isnt 0 or not @opts.lockZeroParamFunctions)
@@ -614,7 +614,7 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
         if not known
           @jsSocketAndMark indentDepth, node.callee, depth + 1, NEVER_PAREN
         else if known.anyobj and node.callee.type is 'MemberExpression'
-          @jsSocketAndMark indentDepth, node.callee.object, depth + 1, NEVER_PAREN
+          @jsSocketAndMark indentDepth, node.callee.object, depth + 1, NEVER_PAREN, null, null, known?.fn?.objectDropdown
         for argument, i in node.arguments
           @jsSocketAndMark indentDepth, argument, depth + 1, NEVER_PAREN, null, null, known?.fn?.dropdown?[i]
         if not known and argCount is 0 and not @opts.lockZeroParamFunctions


### PR DESCRIPTION
* Allow a known function that is considered `known.anyobj` (starting with `*.`) to specify an `objectDropdown` - which is essentially the same as a parameter dropdown, but instead applies to the `callee.object` (the left side of the `MemberExpression`)
* A little known feature allows you to specify `dropdownOnly` inside your dropdown object, which makes the socket non-editable. Unfortunately, the dropdown couldn't change the socket text in this case as well, so I fixed that.
* PR feedback from last PR (https://github.com/droplet-editor/droplet/pull/160): use CoffeeScript existential operator