### PR TITLE
Allow parsing of bare JavaScript ObjectExpression

### DIFF
--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -156,6 +156,9 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
     @lines = @text.split '\n'
 
   markRoot: ->
+    # Socket reparse of `{a: 1}` should be treated as ObjectExpression.
+    @text = "(#{@text})" if @text[0] == '{'
+
     tree = acorn.parse(@text, {
       locations: true
       line: 0

--- a/test/src/jstest.coffee
+++ b/test/src/jstest.coffee
@@ -499,3 +499,24 @@ asyncTest 'JS beginner mode loops', ->
       helper.xmlPrettyPrint(expectedSerialization),
       'Combines if-else')
   start()
+
+asyncTest 'JS object expression', ->
+  customJS = new JavaScript()
+  customSerialization = customJS.parse('{a: 1}').serialize()
+  expectedSerialization =
+    '<document><block ' +
+    'precedence=\"0\" ' +
+    'color=\"teal\" ' +
+    'socketLevel=\"0\" ' +
+    'classes=\"ObjectExpression mostly-value\">({<socket ' +
+    'precedence=\"0\" ' +
+    'handwritten=\"false\" ' +
+    'classes=\"\">a</socket>: <socket ' +
+    'precedence=\"0\" ' +
+    'handwritten=\"false\" ' +
+    'classes=\"\">1</socket>})</block></document>'
+  strictEqual(
+    helper.xmlPrettyPrint(customSerialization),
+    helper.xmlPrettyPrint(expectedSerialization),
+    'Parses bare object expression')
+  start()


### PR DESCRIPTION
Re-opening PR https://github.com/droplet-editor/droplet/pull/168 against the correct branch.

---

Prior to this change, a socket reparse of `{a: 1}` would create a `LabeledStatement` node instead of `ObjectExpression`.

<img width="161" alt="object-expression-in-socket" src="https://cloud.githubusercontent.com/assets/413693/16279172/a5db2f8e-386e-11e6-923c-f41fbed1f857.png">

`LabeledStatement` is an unrecognized node, so `Editor::reparse` doesn't set the correct cursor location.  Subsequent calls to `getCursor`/`setCursor` throw an exception.  To the user it appears the editor is frozen.

This change wraps the program text with parentheses if the text starts with '{'.  Chrome fixed a similar issue in the Dev Tools console (https://bugs.chromium.org/p/chromium/issues/detail?id=499864), however they also check that the text ends with '}'.