### PR TITLE
Semicolon adaptation

### DIFF
--- a/src/languages/c.coffee
+++ b/src/languages/c.coffee
@@ -115,6 +115,28 @@ ADD_PARENS = (leading, trailing, node, context) ->
   leading '(' + leading()
   trailing trailing() + ')'
 
+STATEMENT_TO_EXPRESSION = (leading, trailing, node, context) ->
+  matching = false
+  for c in node.classes when c[...'__parse__'.length] is '__parse__'
+    if c in context.classes
+      matching = true
+      break
+  if matching
+    leading '(' + leading()
+    trailing trailing().replace(/\s*;\s*$/, '') + ')'
+  else
+    trailing trailing().replace(/\s*;\s*$/, '')
+
+EXPRESSION_TO_STATEMENT = (leading, trailing, node, context) ->
+  while true
+    if leading().match(/^\s*\(/)? and trailing().match(/\)\s*/)?
+      leading leading().replace(/^\s*\(\s*/, '')
+      trailing trailing().replace(/\s*\)\s*$/, '')
+    else
+      break
+
+  trailing trailing() + ';'
+
 config.PAREN_RULES = {
   'primaryExpression': {
     'expression': ADD_PARENS
@@ -122,6 +144,15 @@ config.PAREN_RULES = {
     'multiplicativeExpression': ADD_PARENS
     'assignmentExpression': ADD_PARENS
     'postfixExpression': ADD_PARENS
+    'expressionStatement': STATEMENT_TO_EXPRESSION
+    'specialMethodCall': STATEMENT_TO_EXPRESSION
+  }
+  'blockItem': {
+    'expression': EXPRESSION_TO_STATEMENT
+    'additiveExpression': EXPRESSION_TO_STATEMENT
+    'multiplicativeExpression': EXPRESSION_TO_STATEMENT
+    'assignmentExpression': EXPRESSION_TO_STATEMENT
+    'postfixExpression': EXPRESSION_TO_STATEMENT
   }
 }
 

--- a/src/treewalk.coffee
+++ b/src/treewalk.coffee
@@ -239,6 +239,12 @@ exports.createTreewalkParser = (parse, config, root) ->
       if context.parseContext in parseClasses(block)
         return helper.ENCOURAGE
 
+      # Check to see if we could paren-wrap this
+      if config.PAREN_RULES? and context.parseContext of config.PAREN_RULES
+        for m in parseClasses(block)
+          if m of config.PAREN_RULES[context.parseContext]
+            return helper.ENCOURAGE
+
       return helper.DISCOURAGE
 
     else if context.type is 'document'
@@ -263,7 +269,6 @@ exports.createTreewalkParser = (parse, config, root) ->
       else
         return
 
-
     # If we already match types, we're fine
     for c in parseClasses(context)
       if c in parseClasses(node)
@@ -282,4 +287,4 @@ exports.createTreewalkParser = (parse, config, root) ->
 
 PARSE_PREFIX = "__parse__"
 padRules = (rules) -> rules.map (x) -> "#{PARSE_PREFIX}#{x}"
-parseClasses = (node) -> node.classes.filter((x) -> x[...PARSE_PREFIX.length] is PARSE_PREFIX).map((x) -> x[PARSE_PREFIX.length..])
+parseClasses = (node) -> node.classes.filter((x) -> x[...PARSE_PREFIX.length] is PARSE_PREFIX).map((x) -> x[PARSE_PREFIX.length..]).concat(node.parseContext)

--- a/test/src/ctest.coffee
+++ b/test/src/ctest.coffee
@@ -284,6 +284,60 @@ asyncTest 'Controller: ANTLR paren wrap rules', ->
     )
   ]
 
+asyncTest 'Controller: ANTLR paren wrap rules for C semicolons', ->
+  window.editor = editor = new droplet.Editor(document.getElementById('test-main'), {
+    mode: 'c',
+    palette: []
+  })
+
+  editor.setValue '''
+    int main() {
+      puts("Hello");
+      puts("World");
+    }
+  '''
+
+  executeAsyncSequence [
+    (->
+      pickUpLocation editor, 0, {
+        row: 1
+        col: 2
+        type: 'block'
+      }
+      dropLocation editor, 0, {
+        row: 2
+        col: 7
+        type: 'socket'
+      }
+    ), (->
+      equal editor.getValue(), '''
+      int main() {
+        puts(puts("Hello"));
+      }\n
+      ''', 'Removed semicolon dropping function into other function'
+    ), (->
+      pickUpLocation editor, 0, {
+        row: 1
+        col: 7
+        type: 'block'
+      }
+      dropLocation editor, 0, {
+        row: 1
+        col: 2
+        type: 'block'
+      }
+    ), (->
+      equal editor.getValue(), '''
+      int main() {
+        puts("World");
+        puts("Hello");
+      }\n
+      ''', 'Added semicolon dropping function into block'
+
+      start()
+    )
+  ]
+
 asyncTest 'Controller: ANTLR reparse rules', ->
   document.getElementById('test-main').innerHTML = ''
   window.editor = editor = new droplet.Editor(document.getElementById('test-main'), {


### PR DESCRIPTION
Add or remove semicolons as necessary when dropping expressionStatement blocks into blockItem contexts or vice versa.