### PR TITLE
Parse contexts for documents

### DIFF
--- a/css/droplet.css
+++ b/css/droplet.css
@@ -140,8 +140,8 @@
   top: 0px;
   left: 0px;
   -webkit-touch-callout: none;
-  width: 0px;
-  height: 0px;
+  width: 1px;
+  height: 1px;
   padding: 0;
   border: 0;
   margin: 0;

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -130,8 +130,8 @@ class Session
     @dragView = new view.View _drag, helper.extend {}, standardViewSettings, @options.viewSettings ? {}
 
     # ## Document initialization
-    # We start of with an empty document
-    @tree = new model.Document()
+    # We start off with an empty document
+    @tree = new model.Document(@rootContext)
 
     # Line markings
     @markedLines = {}
@@ -1878,6 +1878,8 @@ Editor::inDisplay = (block) -> (block.container ? block).getDocument() in @getDo
 # blocks without a highlight.
 hook 'mouseup', 0, (point, event, state) ->
   if @draggingBlock? and not @lastHighlight? and not @dragReplacing
+    oldParent = @draggingBlock.parent
+
     # Before we put this block into our list of floating blocks,
     # we need to figure out where on the main canvas
     # we are going to render it.
@@ -1922,7 +1924,7 @@ hook 'mouseup', 0, (point, event, state) ->
 
     # Add the undo operation associated
     # with creating this floating block
-    newDocument = new model.Document({roundedSingletons: true})
+    newDocument = new model.Document(oldParent?.parseContext ? @session.mode.rootContext, {roundedSingletons: true})
     newDocument.insert newDocument.start, @draggingBlock
     @pushUndo new FloatingOperation @session.floatingBlocks.length, newDocument, renderPoint, 'create'
 

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -1143,7 +1143,7 @@ exports.DocumentEndToken = class DocumentEndToken extends EndToken
   serialize: -> "</document>"
 
 exports.Document = class Document extends Container
-  constructor: (@opts = {}) ->
+  constructor: (@parseContext, @opts = {}) ->
     @start = new DocumentStartToken this
     @end = new DocumentEndToken this
     @classes = ['__document__']
@@ -1152,7 +1152,7 @@ exports.Document = class Document extends Container
 
     super
 
-  _cloneEmpty: -> new Document(@opts)
+  _cloneEmpty: -> new Document(@parseContext, @opts)
   firstChild: -> return @_firstChild()
 
   _serialize_header: -> "<document>"

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -329,7 +329,7 @@ exports.Parser = class Parser
 
     indentDepth = 0
     stack = []
-    document = new model.Document(); head = document.start
+    document = new model.Document(opts.context ? @rootContext); head = document.start
 
     currentlyCommented = false
 
@@ -644,6 +644,7 @@ exports.wrapParser = (CustomParser) ->
       @endComment = CustomParser.endComment ? '*/'
       @startSingleLineComment = CustomParser.startSingleLineComment
       @getDefaultSelectionRange = CustomParser.getDefaultSelectionRange ? getDefaultSelectionRange
+      @rootContext = CustomParser.rootContext
 
     # TODO kind of hacky assignation of @empty,
     # maybe change the api?

--- a/src/treewalk.coffee
+++ b/src/treewalk.coffee
@@ -235,8 +235,7 @@ exports.createTreewalkParser = (parse, config, root) ->
       if '__comment__' in block.classes
         return helper.ENCOURAGE
 
-      if 'externalDeclaration' in parseClasses(block) or
-         'translationUnit' in parseClasses(block)
+      if context.parseContext in parseClasses(block)
         return helper.ENCOURAGE
 
       return helper.DISCOURAGE
@@ -267,6 +266,8 @@ exports.createTreewalkParser = (parse, config, root) ->
   TreewalkParser.stringFixer = config.stringFixer
   TreewalkParser.getDefaultSelectionRange = config.getDefaultSelectionRange
   TreewalkParser.empty = config.empty
+
+  TreewalkParser.rootContext = root
 
   return TreewalkParser
 


### PR DESCRIPTION
Add a parseContext property to the Document class, so that floating blocks can know what can be dropped in them instead of thinking they are the root context. Also generalizes some C-specific magic strings from treewalker.