### PR TITLE
dont set width on hidden input

### DIFF
--- a/css/droplet.css
+++ b/css/droplet.css
@@ -138,7 +138,8 @@
   z-index: -999;
   opacity: 0;
   -webkit-touch-callout: none;
-  width: 1px;
+  /* Dont set width, as Chrome 57+ this makes it so that typing a space also
+   * inserts a newline */
   height: 1px;
   padding: 0;
   border: 0;


### PR DESCRIPTION
![chromebug](https://cloud.githubusercontent.com/assets/1767466/24815900/c3d37266-1b8b-11e7-88c1-35474b45524e.gif)

When typing text into our hidden textarea, Chrome (starting in version 57) enters a newline every time we press space. Not setting width fixes this.

Tested on Chrome 56, Chrome 57, Safari, Firefox, Edge.