### PR TITLE
pin version of cssmin so we still work on node v0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "grunt-contrib-coffee": "latest",
     "grunt-contrib-concat": "latest",
     "grunt-contrib-connect": "latest",
-    "grunt-contrib-cssmin": "latest",
+    "grunt-contrib-cssmin": "1.0.2",
     "grunt-contrib-qunit": "<=0.5.2",
     "grunt-contrib-uglify": "latest",
     "grunt-contrib-watch": "latest",


### PR DESCRIPTION
newer versions of css-clean use path.isAbsolute which doesn't exist in node v0.10

Without this change travis CI fails at:
```
Running "cssmin:minify" (cssmin) task
>> TypeError: Object #<Object> has no method 'isAbsolute'
Warning: CSS minification failed at css/droplet.css. Use --force to continue.
```

With this change, Travis CI still fails, but later (inside htmltest). That failure also occurs in master. I spent some time trying to understand, without success.