### PR TITLE
Don't throw if a reparsed list has no parent

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -2260,7 +2260,7 @@ Editor::reparse = (list, recovery, updates = [], originalTrigger = list) ->
 
   try
     newList = @mode.parse list.stringifyInPlace(),{
-      wrapAtRoot: parent.type isnt 'socket'
+      wrapAtRoot: parent?.type isnt 'socket'
       context: context
     }
   catch e


### PR DESCRIPTION
Fixes the following edit:

`f(1);`
  -> Edits `1` to `); g(`
  -> Reparse FAILS
  -> Fall back to reparsing the parent
  -> Reparse `f(); g();` as two separate blocks
  -> Finished

Sample edits that throw an exception prior to this change:

![screen shot 2017-04-12 at 2 28 20 pm](https://cloud.githubusercontent.com/assets/413693/25058785/3215b95e-2132-11e7-9b9a-df920e078cde.png)

![screen shot 2017-04-12 at 2 21 38 pm](https://cloud.githubusercontent.com/assets/413693/25058786/34abc262-2132-11e7-8a0d-9fe88e4f96e0.png)