### PR TITLE
pin parse5 to particular version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "acorn": "^1.2.2",
     "sax": "^1.1.1",
     "antlr4": "latest",
-    "parse5": "latest"
+    "parse5": "2.1.5"
   }
 }


### PR DESCRIPTION
Tests were failing, apparently because of something in one of the newer versions of parse5.

What I did was found the last time we had passing tests (June 2016), and found the version of parse5 used backed then. I then pin to that version.

We may (probably) want to pin more versions of packages in our package.json to avoid this problem going forward. I will likely do some of that in a future PR.