### PR TITLE
fix svg dropdowns

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -2782,6 +2782,8 @@ Editor::showDropdown = (socket = @getCursor(), inPalette = false) ->
         dropdownTop -= (@session.fontSize + @dropdownElement.clientHeight)
       @dropdownElement.style.top = dropdownTop + 'px'
     else
+      # Refresh socket after rerender
+      socket = @getCursor()
       location = @session.view.getViewNodeFor(socket).bounds[0]
       @dropdownElement.style.left = location.x - @session.viewports.main.x + @dropletElement.offsetLeft + @gutter.clientWidth + 'px'
       @dropdownElement.style.minWidth = location.width + 'px'


### PR DESCRIPTION
Prior to this change there was the following bug with dropdowns in svg droplet:
![droplet-dropdown-issues](https://user-images.githubusercontent.com/8001765/27567805-0582eb1e-5aa3-11e7-8fd8-4d42cb7075c6.gif)

This only happened when the cursor was previously in a different socket within the same block as the dropdown that was being opened.

The problem was that the `showDropdown` method calls `setTimeout` to wait for a render before showing the dropdown, but it was keeping a reference to the old model id for the dropdown, which had become invalid. The solution is to refresh the socket from the cursor position after the render, before opening the dropdown.