### PR TITLE
replace parentElement with parentNode to fix IE

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -869,14 +869,14 @@ Editor::absoluteOffset = (el) ->
 # Convert a point relative to the page into
 # a point relative to one of the two canvases.
 Editor::trackerPointToMain = (point) ->
-  if not @mainCanvas.parentElement?
+  if not @mainCanvas.parentNode?
     return new @draw.Point(NaN, NaN)
   gbr = @mainCanvas.getBoundingClientRect()
   new @draw.Point(point.x - gbr.left,
                   point.y - gbr.top)
 
 Editor::trackerPointToPalette = (point) ->
-  if not @paletteCanvas.parentElement?
+  if not @paletteCanvas.parentNode?
     return new @draw.Point(NaN, NaN)
   gbr = @paletteCanvas.getBoundingClientRect()
   new @draw.Point(point.x - gbr.left,
@@ -885,7 +885,7 @@ Editor::trackerPointToPalette = (point) ->
 Editor::trackerPointIsInElement = (point, element) ->
   if not @session? or @session.readOnly
     return false
-  if not element.parentElement?
+  if not element.parentNode?
     return false
   gbr = element.getBoundingClientRect()
   return point.x >= gbr.left and point.x < gbr.right and

--- a/src/draw.coffee
+++ b/src/draw.coffee
@@ -129,7 +129,7 @@ exports.Draw = class Draw
         if @element?
           @element.style.display = 'none'
         @active = false
-        @parent = @element?.parentElement ? self.ctx
+        @parent = @element?.parentNode ? self.ctx
 
       manifest: ->
         unless @element?
@@ -138,7 +138,7 @@ exports.Draw = class Draw
 
           unless @active
             @element.style.display = 'none'
-        else unless @element.parentElement?
+        else unless @element.parentNode?
           @getParentElement().appendChild @element
 
       deactivate: ->
@@ -168,13 +168,13 @@ exports.Draw = class Draw
 
         if @element?
           parent = @getParentElement()
-          unless parent is @element.parentElement
+          unless parent is @element.parentNode
             parent.appendChild @element
 
       destroy: ->
         if @element?
-          if @element.parentElement?
-            @element.parentElement.removeChild @element
+          if @element.parentNode?
+            @element.parentNode.removeChild @element
 
     @Group = class Group extends ElementWrapper
       constructor: ->


### PR DESCRIPTION
parentElement is not defined on SVG elements in Internet Explorer, but parentNode is. This brings the time taken to redraw the block palette down from 7 seconds to 0.05 seconds in IE.