### PR TITLE
dont clobber other classnames on .droplet-hover-div

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -830,7 +830,7 @@ Editor::redrawPalette = ->
     # enable tooltips, making sure not to overwrite any additional classes
     # that may have been added (e.g. by tooltipster)
     paletteBlockClass = paletteBlockView.group.element.getAttribute('class')
-    unless paletteBlockClass && paletteBlockClass.includes('droplet-hover-div')
+    unless paletteBlockClass && paletteBlockClass.indexOf('droplet-hover-div') > -1
       paletteBlockView.group.element.setAttribute('class', 'droplet-hover-div')
     paletteBlockView.group.element.setAttribute 'title', entry.title
 

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -829,9 +829,9 @@ Editor::redrawPalette = ->
 
     # enable tooltips, making sure not to overwrite any additional classes
     # that may have been added (e.g. by tooltipster)
-    paletteBlockClass = paletteBlockView.group.element.getAttribute('class')
-    unless paletteBlockClass && paletteBlockClass.indexOf('droplet-hover-div') > -1
-      paletteBlockView.group.element.setAttribute('class', 'droplet-hover-div')
+    paletteBlockClass = paletteBlockView.group.element.getAttribute('class') || ''
+    unless paletteBlockClass.indexOf('droplet-hover-div') > -1
+      paletteBlockView.group.element.setAttribute('class', paletteBlockClass + ' droplet-hover-div')
     paletteBlockView.group.element.setAttribute 'title', entry.title
 
     # Update lastBottomEdge

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -827,8 +827,11 @@ Editor::redrawPalette = ->
 
     paletteBlockView.group.element.setAttribute 'data-id', entry.id
 
-    # enable tooltips
-    paletteBlockView.group.element.setAttribute('class', 'droplet-hover-div')
+    # enable tooltips, making sure not to overwrite any additional classes
+    # that may have been added (e.g. by tooltipster)
+    paletteBlockClass = paletteBlockView.group.element.getAttribute('class')
+    unless paletteBlockClass && paletteBlockClass.includes('droplet-hover-div')
+      paletteBlockView.group.element.setAttribute('class', 'droplet-hover-div')
     paletteBlockView.group.element.setAttribute 'title', entry.title
 
     # Update lastBottomEdge
@@ -1807,7 +1810,7 @@ hook 'mouseup', 1, (point, event, state) ->
       hadTextToken = @draggingBlock.start.next.type is 'text'
 
       @spliceOut @draggingBlock
-      
+
       # Remove these attributes (that are present on some blocks dragged from
       # the palette) before splicing in
       @draggingBlock.expansion = null


### PR DESCRIPTION
We need to preserve the `.tooltipstered` class on the `.droplet-hover-div` when the palette is redrawn, so that we can hide the tooltip here https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/blockTooltips/DropletBlockTooltipManager.js#L117-L121 when a block is selected.