### PR TITLE
Redraw after toggle palette

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -3803,6 +3803,8 @@ Editor::enablePalette = (enabled) ->
 
         @currentlyAnimating = false
 
+        @redrawMain()
+
         @fireEvent 'palettetoggledone', [@session.paletteEnabled]
       ), 500
 
@@ -3825,6 +3827,8 @@ Editor::enablePalette = (enabled) ->
           @resize()
 
           @currentlyAnimating = false
+
+          @redrawMain()
 
           @fireEvent 'palettetoggledone', [@session.paletteEnabled]
         ), 500


### PR DESCRIPTION
This fixes the issue where the droplet block text disappears after the toolbox is shown or hidden. I'm not adding a test for this, since this regression was already caught by our existing eyes tests.