### PR TITLE
Update dropdowns to extend outside the coding workspace

### DIFF
--- a/css/droplet.css
+++ b/css/droplet.css
@@ -71,7 +71,7 @@
   position: absolute;
   top: 0; bottom: 0; width: 300px;
   max-width: 40%;
-  z-index:0;
+  z-index: 0;
   -webkit-user-select: none;
   -khtml-user-select: none;
   -moz-user-select: none;

--- a/css/droplet.css
+++ b/css/droplet.css
@@ -71,7 +71,7 @@
   position: absolute;
   top: 0; bottom: 0; width: 300px;
   max-width: 40%;
-  z-index: 257;
+  z-index:0;
   -webkit-user-select: none;
   -khtml-user-select: none;
   -moz-user-select: none;
@@ -263,7 +263,7 @@
   max-height: 150px;
   position: absolute;
   background-color: #FFF;
-  z-index: 10000;
+  z-index: 500;
   border: 1px solid #DDD;
   border-radius: 2px;
   overflow-y: auto;

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -278,7 +278,6 @@ exports.Editor = class Editor
         @wrapperElement.style.left =
         @wrapperElement.style.top =
         @wrapperElement.style.bottom = '0px'
-      @wrapperElement.style.overflow = 'hidden'
 
       @aceElement = document.createElement 'div'
       @aceElement.className = 'droplet-ace'
@@ -301,7 +300,6 @@ exports.Editor = class Editor
         @wrapperElement.style.left =
         @wrapperElement.style.top =
         @wrapperElement.style.bottom = '0px'
-      @wrapperElement.style.overflow = 'hidden'
 
       @aceElement = @aceEditor.container
       @aceElement.className += ' droplet-ace'
@@ -493,9 +491,6 @@ exports.Editor = class Editor
   resizePalette: ->
     for binding in editorBindings.resize_palette
       binding.call this
-
-    unless @session?.currentlyUsingBlocks or @session?.showPaletteInTextMode and @session?.paletteEnabled
-     @paletteWrapper.style.left = "#{-@paletteWrapper.clientWidth}px"
 
     @rebuildPalette()
 
@@ -3633,17 +3628,13 @@ Editor::performMeltAnimation = (fadeTime = 500, translateTime = 1000, cb = ->) -
       @paletteHeader.style.zIndex = 0
 
       setTimeout (=>
-        @dropletElement.style.transition =
-          @paletteWrapper.style.transition = "left #{translateTime}ms"
-
+        @dropletElement.style.transition = "left #{translateTime}ms"
         @dropletElement.style.left = '0px'
-        @paletteWrapper.style.left = "#{-@paletteWrapper.clientWidth}px"
       ), fadeTime
 
     setTimeout (=>
       # Translate the ICE editor div out of frame.
-      @dropletElement.style.transition =
-        @paletteWrapper.style.transition = ''
+      @dropletElement.style.transition = ''
 
       # Translate the ACE editor div into frame.
       @aceElement.style.top = '0px'
@@ -3722,7 +3713,6 @@ Editor::performFreezeAnimation = (fadeTime = 500, translateTime = 500, cb = ->)-
 
       if paletteAppearingWithFreeze
         @paletteWrapper.style.top = '0px'
-        @paletteWrapper.style.left = "#{-@paletteWrapper.clientWidth}px"
         @paletteHeader.style.zIndex = 0
 
       @dropletElement.style.top = "0px"
@@ -3814,13 +3804,11 @@ Editor::performFreezeAnimation = (fadeTime = 500, translateTime = 500, cb = ->)-
       @dropletElement.style.transition = "left #{fadeTime}ms"
 
       if paletteAppearingWithFreeze
-        @paletteWrapper.style.transition = @dropletElement.style.transition
         @dropletElement.style.left = "#{@paletteWrapper.clientWidth}px"
         @paletteWrapper.style.left = '0px'
 
       setTimeout (=>
-        @dropletElement.style.transition =
-          @paletteWrapper.style.transition = ''
+        @dropletElement.style.transition = ''
 
         # Show scrollbars again
         @showScrollbars()
@@ -3855,19 +3843,16 @@ Editor::enablePalette = (enabled) ->
       activeElement = @aceElement
 
     if not @session.paletteEnabled
-      activeElement.style.transition =
-        @paletteWrapper.style.transition = "left 500ms"
+      activeElement.style.transition = "left 500ms"
 
       activeElement.style.left = '0px'
-      @paletteWrapper.style.left = "#{-@paletteWrapper.clientWidth}px"
 
       @paletteHeader.style.zIndex = 0
 
       @resize()
 
       setTimeout (=>
-        activeElement.style.transition =
-          @paletteWrapper.style.transition = ''
+        activeElement.style.transition = ''
 
         #@paletteWrapper.style.top = '-9999px'
         #@paletteWrapper.style.left = '-9999px'
@@ -3881,19 +3866,16 @@ Editor::enablePalette = (enabled) ->
 
     else
       @paletteWrapper.style.top = '0px'
-      @paletteWrapper.style.left = "#{-@paletteWrapper.clientWidth}px"
       @paletteHeader.style.zIndex = 257
 
       setTimeout (=>
-        activeElement.style.transition =
-          @paletteWrapper.style.transition = "left 500ms"
+        activeElement.style.transition = "left 500ms"
 
         activeElement.style.left = "#{@paletteWrapper.clientWidth}px"
         @paletteWrapper.style.left = '0px'
 
         setTimeout (=>
-          activeElement.style.transition =
-            @paletteWrapper.style.transition = ''
+          activeElement.style.transition = ''
 
           @resize()
 
@@ -4241,8 +4223,7 @@ Editor::hasEvent = (event) -> event of @bindings and @bindings[event]?
 # ================================
 
 Editor::setEditorState = (useBlocks) ->
-  @mainCanvas.style.transition = @paletteWrapper.style.transition =
-    @highlightCanvas.style.transition = ''
+  @mainCanvas.style.transition = @highlightCanvas.style.transition = ''
 
   if useBlocks
     if not @session?
@@ -4257,7 +4238,6 @@ Editor::setEditorState = (useBlocks) ->
       @dropletElement.style.left = "#{@paletteWrapper.clientWidth}px"
     else
       @paletteWrapper.style.top = '0px'
-      @paletteWrapper.style.left = "#{-@paletteWrapper.clientWidth}px"
       @dropletElement.style.left = '0px'
 
     @aceElement.style.top = @aceElement.style.left = '-9999px'
@@ -4291,11 +4271,7 @@ Editor::setEditorState = (useBlocks) ->
     @aceEditor.session.setScrollTop oldScrollTop
 
     @dropletElement.style.top = @dropletElement.style.left = '-9999px'
-    if paletteVisibleInNewState
-      @paletteWrapper.style.top = @paletteWrapper.style.left = '0px'
-    else
-      @paletteWrapper.style.top = '0px'
-      @paletteWrapper.style.left = "#{-@paletteWrapper.clientWidth}px"
+    @paletteWrapper.style.top = @paletteWrapper.style.left = '0px'
 
     @aceElement.style.top = '0px'
     if paletteVisibleInNewState

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -248,6 +248,7 @@ exports.Editor = class Editor
     @draw = new draw.Draw(@mainCanvas)
 
     @dropletElement.style.left = @paletteWrapper.clientWidth + 'px'
+    @dropletElement.style.zIndex = 1
 
     do @draw.refreshFontCapital
 
@@ -306,6 +307,8 @@ exports.Editor = class Editor
 
       @aceEditor.container.parentElement.appendChild @wrapperElement
       @wrapperElement.appendChild @aceEditor.container
+
+    @aceElement.style.zIndex = 1
 
     # Append populated divs
     @wrapperElement.appendChild @dropletElement

--- a/test/src/tests.coffee
+++ b/test/src/tests.coffee
@@ -792,7 +792,7 @@ asyncTest 'Controller: showPaletteInTextMode false', ->
     states.push usingBlocks
 
   editor.performMeltAnimation 10, 10, ->
-    strictEqual paletteWrapper.style.left, '-270px'
+    strictEqual paletteWrapper.style.left, '0px'
     strictEqual aceEditor.style.left, '0px'
     editor.performFreezeAnimation 10, 10, ->
       strictEqual paletteWrapper.style.left, '0px'
@@ -840,7 +840,7 @@ asyncTest 'Controller: enablePalette false', ->
   strictEqual dropletWrapper.style.left, '270px'
 
   verifyPaletteHidden = ->
-    strictEqual paletteWrapper.style.left, '-270px'
+    strictEqual paletteWrapper.style.left, '0px'
     strictEqual dropletWrapper.style.left, '0px'
     start()
 

--- a/test/src/uitest.coffee
+++ b/test/src/uitest.coffee
@@ -976,9 +976,16 @@ asyncTest 'Controller: Session switch test', ->
       equal editor.paletteHeader.childElementCount, 0, 'Palette header now empty'
 
       equal editor.paletteWrapper.style.left is '0px', true, 'Using blocks'
+      equal editor.dropletElement.style.top is '0px', true, 'droplet visible'
+      equal editor.dropletElement.style.left is '270px', true, 'droplet next to palette'
+      equal editor.aceElement.style.top is '-9999px', true, 'ace element offscreen'
+
       editor.setEditorState(false)
 
       equal editor.paletteWrapper.style.left is '0px', true, 'No longer using blocks'
+      equal editor.dropletElement.style.top is '-9999px', true, 'droplet offscreen'
+      equal editor.aceElement.style.top is '0px', true, 'ace element visible'
+      equal editor.aceElement.style.left is '0px', true, 'palette covered by ace element'
     ),
     (->
       editor.aceEditor.setSession originalSession
@@ -993,6 +1000,9 @@ asyncTest 'Controller: Session switch test', ->
       ''', 'Original text restored'
 
       equal editor.paletteWrapper.style.left is '0px', true, 'Using blocks again'
+      equal editor.dropletElement.style.top is '0px', true, 'droplet visible'
+      equal editor.dropletElement.style.left is '270px', true, 'droplet next to palette'
+      equal editor.aceElement.style.top is '-9999px', true, 'ace element offscreen'
       equal editor.paletteHeader.childElementCount, 3, 'Original palette header size restored'
     ),
     (->
@@ -1012,6 +1022,9 @@ asyncTest 'Controller: Session switch test', ->
 
       equal editor.paletteWrapper.style.left is '0px', true, 'No longer using blocks'
       equal editor.paletteHeader.childElementCount, 0, 'Palette header now empty'
+      equal editor.aceElement.style.left is '0px', true, 'ace on top of palette'
+      equal editor.aceElement.style.top is '0px', true, 'ace element visible'
+      equal editor.dropletElement.style.top is '-9999px', true, 'droplet offscreen'
 
       start()
     )

--- a/test/src/uitest.coffee
+++ b/test/src/uitest.coffee
@@ -978,7 +978,7 @@ asyncTest 'Controller: Session switch test', ->
       equal editor.paletteWrapper.style.left is '0px', true, 'Using blocks'
       editor.setEditorState(false)
 
-      equal editor.paletteWrapper.style.left is '0px', false, 'No longer using blocks'
+      equal editor.paletteWrapper.style.left is '0px', true, 'No longer using blocks'
     ),
     (->
       editor.aceEditor.setSession originalSession
@@ -1010,7 +1010,7 @@ asyncTest 'Controller: Session switch test', ->
       }\n
       ''', 'Set value of new session'
 
-      equal editor.paletteWrapper.style.left is '0px', false, 'No longer using blocks'
+      equal editor.paletteWrapper.style.left is '0px', true, 'No longer using blocks'
       equal editor.paletteHeader.childElementCount, 0, 'Palette header now empty'
 
       start()


### PR DESCRIPTION
Relates to this PR: https://github.com/code-dot-org/code-dot-org/pull/29588
Ticket: https://codedotorg.atlassian.net/browse/STAR-461

Droplet dropdowns now render in front of other parts of the screen and respect their z-index.

In the past, the code workspace had all overflows set to "hidden" this effectively caused the droplet dropdowns to ignore their z-index and hide any section that interacted with another component on the screen. It would appear to render under these components. This "hidden" overflow was used to make the droplet palette "disappear" when the palette was closed because it would interact with elements outside the code workspace. This change removes the "hidden" overflow. Additionally, it adjusts the palette to disappear under the code workspace when closed rather than disappear under the app screen when closed.

**Dropdown before:**
![image](https://user-images.githubusercontent.com/8324574/60931192-7c2d7680-a26d-11e9-9693-e70589231a06.png)

**Dropdown after:**
![image](https://user-images.githubusercontent.com/8324574/60931200-83ed1b00-a26d-11e9-81a8-79016860e149.png)

**Palette before:**
![oldToolbox](https://user-images.githubusercontent.com/8324574/60931270-d3334b80-a26d-11e9-9c22-dbabd9eb09c0.gif)

**Palette after:**
![newToolbox2](https://user-images.githubusercontent.com/8324574/61250615-fdbd5280-a70c-11e9-89b1-2c4c430871b1.gif)

**[CS50 Compatibility] After these changes**
![cs50Demo](https://user-images.githubusercontent.com/8324574/61330999-cff01080-a7d5-11e9-9f7a-c17173c58130.gif)





**FOR RECORDS (NO LONGER ACCURATE - fixed after comments) Palette after:**
![newToolbox](https://user-images.githubusercontent.com/8324574/60931304-f0681a00-a26d-11e9-8b62-4034b24d2b18.gif)