### PR TITLE
Added parse function and added line numbers to error messaging

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -3394,6 +3394,14 @@ containsCursor = (block) ->
 # ANIMATION AND ACE EDITOR SUPPORT
 # ================================
 
+# Checks whether the current code is possible to parse. If yes, returns the
+# parsed code. Else will throw an error.
+Editor::parse = ->
+  return @session.mode.parse @getAceValue(), {
+    wrapAtRoot: true
+    preserveEmpty: @session.options.preserveEmpty
+  }
+
 Editor::copyAceEditor = ->
   @gutter.style.width = @aceEditor.renderer.$gutterLayer.gutterWidth + 'px'
   @resizeBlockMode()

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -439,19 +439,22 @@ exports.Parser = class Parser
               # An Indent is only allowed to be
               # directly inside a block; if not, then throw.
               unless stack?[stack.length - 1]?.type is 'block'
-                throw new Error 'Improper parser: indent must be inside block, but is inside ' + stack?[stack.length - 1]?.type
+                # Include line numbers for upstream error handling.
+                throw new Error "Line #{mark.location.line}. Improper parser: indent must be inside block, but is inside #{stack?[stack.length - 1]?.type}"
               indentDepth += mark.token.container.prefix.length
 
             when 'blockStart'
               # If the a block is embedded
               # directly in another block, throw.
               if stack[stack.length - 1]?.type is 'block'
-                throw new Error 'Improper parser: block cannot nest immediately inside another block.'
+                # Include line numbers for upstream error handling.
+                throw new Error "Line #{mark.location.line}. Improper parser: block cannot nest immediately inside another block."
 
             when 'socketStart'
               # A socket is only allowed to be directly inside a block.
               unless stack[stack.length - 1]?.type is 'block'
-                throw new Error 'Improper parser: socket must be immediately inside a block.'
+                # Include line numbers for upstream error handling.
+                throw new Error "Line #{mark.location.line}. Improper parser: socket must be immediately inside a block."
 
             when 'indentEnd'
               indentDepth -= mark.token.container.prefix.length
@@ -461,7 +464,8 @@ exports.Parser = class Parser
             stack.push mark.token.container
           else if mark.token instanceof model.EndToken
             unless mark.token.container is stack[stack.length - 1]
-              throw new Error "Improper parser: #{head.container.type} ended too early."
+              # Include line numbers for upstream error handling.
+              throw new Error "Line #{mark.location.line}. Improper parser: #{head.container.type} ended too early."
             stack.pop()
 
           # Append the token

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -432,6 +432,9 @@ exports.Parser = class Parser
               head = helper.connect head, stack.pop().end
               currentlyCommented = false
 
+          # Include line numbers for upstream error handling.
+          error = {line: mark.location.line}
+
           # Note, if we have inserted something,
           # the new indent depth and the new stack.
           switch mark.token.type
@@ -439,22 +442,28 @@ exports.Parser = class Parser
               # An Indent is only allowed to be
               # directly inside a block; if not, then throw.
               unless stack?[stack.length - 1]?.type is 'block'
-                # Include line numbers for upstream error handling.
-                throw new Error "Line #{mark.location.line}. Improper parser: indent must be inside block, but is inside #{stack?[stack.length - 1]?.type}"
+                # Set types for the error so we can parse them upstream.
+                error.type = "IncorrectBlockParent"
+                error.message = "Improper parser: indent must be inside block, but is inside #{stack?[stack.length - 1]?.type}"
+                throw new Error JSON.stringify error
               indentDepth += mark.token.container.prefix.length
 
             when 'blockStart'
               # If the a block is embedded
               # directly in another block, throw.
               if stack[stack.length - 1]?.type is 'block'
-                # Include line numbers for upstream error handling.
-                throw new Error "Line #{mark.location.line}. Improper parser: block cannot nest immediately inside another block."
+                # Set types for the error so we can parse them upstream.
+                error.type = "DropletParseError"
+                error.message = "Improper parser: block cannot nest immediately inside another block."
+                throw new Error JSON.stringify error
 
             when 'socketStart'
               # A socket is only allowed to be directly inside a block.
               unless stack[stack.length - 1]?.type is 'block'
-                # Include line numbers for upstream error handling.
-                throw new Error "Line #{mark.location.line}. Improper parser: socket must be immediately inside a block."
+                # Set types for the error so we can parse them upstream.
+                error.type = "DropletParseError"
+                error.message = "Improper parser: socket must be immediately inside a block."
+                throw new Error JSON.stringify error
 
             when 'indentEnd'
               indentDepth -= mark.token.container.prefix.length
@@ -464,8 +473,10 @@ exports.Parser = class Parser
             stack.push mark.token.container
           else if mark.token instanceof model.EndToken
             unless mark.token.container is stack[stack.length - 1]
-              # Include line numbers for upstream error handling.
-              throw new Error "Line #{mark.location.line}. Improper parser: #{head.container.type} ended too early."
+              # Set types for the error so we can parse them upstream.
+              error.type = "DropletParseError"
+              error.message = "Improper parser: #{head.container.type} ended too early."
+              throw new Error JSON.stringify error
             stack.pop()
 
           # Append the token


### PR DESCRIPTION
Relates to this PR in the code-dot-org repository: https://github.com/code-dot-org/code-dot-org/pull/35413

This exposes the droplet parser so that users of the droplet parser can detect and handle errors before rendering. Additionally, the error messages created while parsing did not have line numbers and were difficult to communicate to users. Line numbers are added as part of this PR as well.