### PR TITLE
Support for createSlotForKnownBlock option

### DIFF
--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -659,6 +659,10 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
         else if known.anyobj and node.callee.type is 'MemberExpression'
           @jsSocketAndMark indentDepth, node.callee.object, depth + 1, NEVER_PAREN, null, null, known?.fn?.objectDropdown
         else if known and node.callee.type is 'MemberExpression' and @opts.createSocketForKnownBlock
+          # We have a known block, and while we will not create a socket for the callee.property
+          # (e.g. ".toUpperCase()") we would like a socket for the callee.object (e.g. "getText()").
+          # A precedence of 3 seems to preserve the parens around the socket content in "('text' + getText()).toUpperCase()" while
+          # not adding them in "getText().length".
           @jsSocketAndMark indentDepth, node.callee.object, depth + 1, 3, null, null, known?.fn?.objectDropdown
         for argument, i in node.arguments
           noFunctionDrop = @opts.lockFunctionDropIntoKnownParams and known?.fn and not known?.fn?.allowFunctionDrop?[i]
@@ -701,6 +705,8 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
         else if known and @opts.createSocketForKnownBlock
           # We have a known block, and while we will not create a socket for the property
           # (e.g. ".length") we would like a socket for the object (e.g. "getText()").
+          # A precedence of 3 seems to preserve the parens around the socket content in "('text' + getText()).length" while
+          # not adding them in "getText().length".
           @jsSocketAndMark indentDepth, node.object, depth + 1, 3
       when 'UpdateExpression'
         @jsBlock node, depth, bounds

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -696,9 +696,9 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
           @jsSocketAndMark indentDepth, node.property, depth + 1
         if not known or known.anyobj
           @jsSocketAndMark indentDepth, node.object, depth + 1
-        else if known and @opts.createSlotForKnownBlock
+        else if known and @opts.createSocketForKnownBlock
           # We have a known block, and while we will not create a socket for the property
-          # (e.g. ".length") we would like a slot for the object (e.g. "getText()").
+          # (e.g. ".length") we would like a socket for the object (e.g. "getText()").
           @jsSocketAndMark indentDepth, node.object, depth + 1, NEVER_PAREN
       when 'UpdateExpression'
         @jsBlock node, depth, bounds

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -659,7 +659,7 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
         else if known.anyobj and node.callee.type is 'MemberExpression'
           @jsSocketAndMark indentDepth, node.callee.object, depth + 1, NEVER_PAREN, null, null, known?.fn?.objectDropdown
         else if known and node.callee.type is 'MemberExpression' and @opts.createSocketForKnownBlock
-          @jsSocketAndMark indentDepth, node.callee.object, depth + 1, NEVER_PAREN, null, null, known?.fn?.objectDropdown
+          @jsSocketAndMark indentDepth, node.callee.object, depth + 1, null, null, null, known?.fn?.objectDropdown
         for argument, i in node.arguments
           noFunctionDrop = @opts.lockFunctionDropIntoKnownParams and known?.fn and not known?.fn?.allowFunctionDrop?[i]
           classes = if noFunctionDrop then ['no-function-drop'] else null
@@ -701,7 +701,7 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
         else if known and @opts.createSocketForKnownBlock
           # We have a known block, and while we will not create a socket for the property
           # (e.g. ".length") we would like a socket for the object (e.g. "getText()").
-          @jsSocketAndMark indentDepth, node.object, depth + 1, NEVER_PAREN
+          @jsSocketAndMark indentDepth, node.object, depth + 1
       when 'UpdateExpression'
         @jsBlock node, depth, bounds
         @jsSocketAndMark indentDepth, node.argument, depth + 1

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -658,6 +658,8 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
           @jsSocketAndMark indentDepth, node.callee, depth + 1, NEVER_PAREN
         else if known.anyobj and node.callee.type is 'MemberExpression'
           @jsSocketAndMark indentDepth, node.callee.object, depth + 1, NEVER_PAREN, null, null, known?.fn?.objectDropdown
+        else if known and node.callee.type is 'MemberExpression' and @opts.createSocketForKnownBlock
+          @jsSocketAndMark indentDepth, node.callee.object, depth + 1, NEVER_PAREN, null, null, known?.fn?.objectDropdown
         for argument, i in node.arguments
           noFunctionDrop = @opts.lockFunctionDropIntoKnownParams and known?.fn and not known?.fn?.allowFunctionDrop?[i]
           classes = if noFunctionDrop then ['no-function-drop'] else null

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -659,7 +659,7 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
         else if known.anyobj and node.callee.type is 'MemberExpression'
           @jsSocketAndMark indentDepth, node.callee.object, depth + 1, NEVER_PAREN, null, null, known?.fn?.objectDropdown
         else if known and node.callee.type is 'MemberExpression' and @opts.createSocketForKnownBlock
-          @jsSocketAndMark indentDepth, node.callee.object, depth + 1, null, null, null, known?.fn?.objectDropdown
+          @jsSocketAndMark indentDepth, node.callee.object, depth + 1, 3, null, null, known?.fn?.objectDropdown
         for argument, i in node.arguments
           noFunctionDrop = @opts.lockFunctionDropIntoKnownParams and known?.fn and not known?.fn?.allowFunctionDrop?[i]
           classes = if noFunctionDrop then ['no-function-drop'] else null
@@ -701,7 +701,7 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
         else if known and @opts.createSocketForKnownBlock
           # We have a known block, and while we will not create a socket for the property
           # (e.g. ".length") we would like a socket for the object (e.g. "getText()").
-          @jsSocketAndMark indentDepth, node.object, depth + 1
+          @jsSocketAndMark indentDepth, node.object, depth + 1, 3
       when 'UpdateExpression'
         @jsBlock node, depth, bounds
         @jsSocketAndMark indentDepth, node.argument, depth + 1

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -696,6 +696,10 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
           @jsSocketAndMark indentDepth, node.property, depth + 1
         if not known or known.anyobj
           @jsSocketAndMark indentDepth, node.object, depth + 1
+        else if known and @opts.createSlotForKnownBlock
+          # We have a known block, and while we will not create a socket for the property
+          # (e.g. ".length") we would like a slot for the object (e.g. "getText()").
+          @jsSocketAndMark indentDepth, node.object, depth + 1, NEVER_PAREN
       when 'UpdateExpression'
         @jsBlock node, depth, bounds
         @jsSocketAndMark indentDepth, node.argument, depth + 1


### PR DESCRIPTION
See https://github.com/code-dot-org/code-dot-org/pull/45868 for full details.

Note that `DROPLET_LANGUAGE=javascript grunt dist` was used to build the files in `dist/` that were then copied into the main `code-dot-org` repo.
