### PR TITLE
Fix JS error

### DIFF
--- a/src/view.coffee
+++ b/src/view.coffee
@@ -160,7 +160,7 @@ exports.View = class View
 
   clearMarks: ->
     for key, val of @marks
-      @map[key].unmark()
+      @map[key]?.unmark()
     @marks = {}
 
   beginDraw: ->


### PR DESCRIPTION
The New Relic JavaScript error tracking for https://studio.code.org reports its top error as:
```
Error: Cannot read properties of undefined (reading 'unmark')
```

I've not been able to repro, but believe this fix should fix the error, hopefully without any noticeable side effects.