### PR TITLE
Fix another JS error

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -1612,7 +1612,7 @@ hook 'mousemove', 1, (point, event, state) ->
                   acceptLevel: acceptLevel
                   _droplet_node: head.container
 
-        head = head.next
+        head = head?.next
 
     @dragCanvas.style.transform = "translate(#{position.x + getOffsetLeft(@dropletElement)}px,#{position.y + getOffsetTop(@dropletElement)}px)"
 


### PR DESCRIPTION
The New Relic JavaScript error tracking for https://studio.code.org/ now reports its top error as:
```
Cannot read properties of null (reading 'next')
```
I matched it to this line of code.  

I don't have a repro or a root cause, but my speculation is that `head` be set to `null` [here](https://github.com/droplet-editor/droplet/compare/code-dot-org...code-dot-org-fix-another-js-error?expand=1#diff-4491675cc57100e1234fbf2c8841e392345aa39d441004b64a60c06db7488fbcR1591).  