### PR TITLE
Update parsing of for statement

### DIFF
--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -605,7 +605,15 @@ exports.JavaScriptParser = class JavaScriptParser extends parser.Parser
           if node.update?
             @jsSocketAndMark indentDepth, node.update, depth + 1, 10, null, ['for-statement-update']
 
-        @mark indentDepth, node.body, depth + 1
+        # Check if body is already a block, i.e., the body is wrapped by curly braces.
+        if node.body.type is 'BlockStatement'
+          @mark indentDepth, node.body, depth + 1
+        else
+          @addIndent
+            bounds: @getBounds node.body
+            depth: depth + 1
+            prefix: @getIndentPrefix @getBounds(node.body), indentDepth
+          @mark indentDepth + DEFAULT_INDENT_DEPTH.length, node.body, depth + 1
       when 'BlockStatement'
         prefix = @getIndentPrefix(@getBounds(node), indentDepth)
         indentDepth += prefix.length


### PR DESCRIPTION
This PR updates the parsing of the for loop in Droplet so that single line for loops such as:
```
for (var i=0; i<4; i++)
   console.log(i);
```
are able to be converted from text -> block mode.

Initally, I thought I could just duplicate how the while loop is processed because single line while loops are currently able to be converted from text -> block. 

<img width="296" alt="Screenshot 2025-03-10 at 3 14 22 PM" src="https://github.com/user-attachments/assets/d25f3160-89d8-4db6-b3c5-237cf4e4f434" />


However, [that approach](https://github.com/code-dot-org/code-dot-org/pull/64408) did not work! 
There is a comment that explains that the parsing a for loop is more complex because there are multiple versions of a for loop (standard, 'for...in', for...of').

https://github.com/code-dot-org/code-dot-org/blob/40ff09809f0c5999bfd7d7c21679d9a5f1156499/apps/lib/droplet/droplet-full.js#L19266-L19272



This was the logged error when a user clicked on the toggle button trying to convert from text -> block mode:
![Screenshot 2025-03-07 at 3 42 56 PM](https://github.com/user-attachments/assets/aeae48a1-55e4-4b7f-84bf-14f8b42bd636)

And this error is thrown at:

https://github.com/code-dot-org/code-dot-org/blob/df40e51102e36f4f3d32f77bfa64c1227a5944ec/apps/lib/droplet/droplet-full.js#L15187-L15191

The error is thrown because the correct indentation structure is not provided before inserting the for loop body into the for loop block. 

For context, a block statement is a block of code wrapped by curly braces. See definition of `parseBlock` function:

https://github.com/code-dot-org/code-dot-org/blob/40ff09809f0c5999bfd7d7c21679d9a5f1156499/apps/lib/droplet/droplet-full.js#L19451-L19466

In order to resolve this issue, I included a check for `node.body.type`. If curly braces were included, the parsing was already working as expected so `this.mark` is still called as-is.

However, for the case when the for loop body is not wrapped by curly braces, we want to only add an indent before processing the next block of code.

Caveat: This only adds the ability to toggle between text and block mode for single line for loops.
This does not allow the conversion from text -> block mode in the case of a single line for...in loop.
for...of loops are not allowed in Applab so I was not able to test that case.
However, a user can still use a for...in loop with curly braces and can toggle successfully between text and block mode.

## Before update

https://github.com/user-attachments/assets/9595fb34-4155-478c-8fe5-404f33a2a122




## After update

https://github.com/user-attachments/assets/1234d23e-173a-4c30-b028-0b76c20c9672

## Links
jira - https://codedotorg.atlassian.net/browse/AFL-405
[Slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1741288796978519)
[Zendesk ticket](https://codeorg.zendesk.com/agent/tickets/530786)