### PR TITLE
Add a null check for session tree in getValue

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -56,6 +56,8 @@ module.exports = (grunt) ->
           viewportSize:
             width: 1000
             height: 1000
+        puppeteer:
+          args: ['--no-sandbox']
       all:
         urls:
           (for x in grunt.file.expand('test/*.html')

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -4197,7 +4197,7 @@ Editor::addEmptyLine = (str) ->
     return str + '\n'
 
 Editor::getValue = ->
-  if @session?.currentlyUsingBlocks
+  if @session?.currentlyUsingBlocks and @session?.tree
     return @addEmptyLine @session.tree.stringify({
       preserveEmpty: @session.options.preserveEmpty
     })


### PR DESCRIPTION
We have seen frequent errors pointing back to droplet's editor.getValue method failing. The error we are seeing is `Cannot read properties of null (reading 'stringify')`. This seems to point to `@session.tree` being null when we try to stringify it in this method. I have not been able to repro this locally or on prod. However, I think this change is safe to make. If the tree is null, we will fall back to the ace editor value. It seems like the editor value stays relatively up to date even when in blocks mode, although it tends to start out 1 change behind based on my test logging, then catch up. I think this is better than failing to save at all in the case where the tree becomes null.

Once this is in, I'll run `DROPLET_LANGUAGE=javascript grunt dist` to build the files in `dist/`, then copy those files into the code-dot-org repo.