### PR TITLE
Fixes XSS issue with image names in dropdowns.

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -2805,7 +2805,7 @@ Editor::showDropdown = (socket = @getCursor(), inPalette = false) ->
 
   for el, i in @getDropdownList(socket) then do (el) =>
     div = document.createElement 'div'
-    div.innerHTML = el.display
+    div.textContent = el.display
     div.className = 'droplet-dropdown-item'
 
     dropdownItems.push div


### PR DESCRIPTION
Dropdown options are generated via `innerHTML` and they should be set via `textContent`.

We always generate dropdowns with text in them. We don't actually want to pass in rich content.